### PR TITLE
chore: committed commit-msg hook (survives re-clone)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Block any AI/Claude attribution from landing in a commit message.
+# Hard rule: commits are published under the human developer's identity.
+#
+# This hook is committed to the repo under .githooks/ and activated via
+# `git config core.hooksPath .githooks` (the Gradle `installGitHooks` task
+# does this automatically on build). It therefore survives a fresh clone:
+# the file is versioned, and the first `./gradlew` build re-points hooksPath.
+
+msg_file="$1"
+
+# Case-insensitive patterns that must never appear in a commit message.
+if grep -iqE 'claude|anthropic|co-authored-by:.*claude|generated with claude|🤖' "$msg_file"; then
+    echo "------------------------------------------------------------------" >&2
+    echo "COMMIT REJECTED: AI/Claude attribution detected in commit message." >&2
+    echo "Remove any 'Claude', 'Anthropic', 'Co-Authored-By: Claude'," >&2
+    echo "'Generated with Claude Code', or 🤖 lines, then commit again." >&2
+    echo "------------------------------------------------------------------" >&2
+    exit 1
+fi
+
+exit 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,25 @@ tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
 
+// Point git at the committed .githooks/ directory so the commit-msg guard
+// (rejects accidental Claude/Anthropic attribution) survives a fresh clone.
+// The hook file is versioned; this task re-points core.hooksPath after clone.
+val installGitHooks by tasks.registering(Exec::class) {
+    group = "git hooks"
+    description = "Set git core.hooksPath to the committed .githooks directory."
+    onlyIf { rootProject.file(".git").exists() }
+    commandLine("git", "config", "core.hooksPath", ".githooks")
+}
+
+// Wire hook installation into every module's build/check so the first
+// `./gradlew build` on a fresh clone activates the hooks automatically.
+subprojects {
+    afterEvaluate {
+        tasks.matching { it.name == "build" || it.name == "check" }
+            .configureEach { dependsOn(installGitHooks) }
+    }
+}
+
 // Wipes the Maven staging dir so a new bundle can never accidentally pick up
 // artifacts from a previous run (e.g. the older version's `.module` files when
 // you bump from 2.4.3 → 2.5.0 in the same workspace). Must run BEFORE the


### PR DESCRIPTION
## Summary

Makes the commit-message attribution guard survive a fresh clone.

Previously the guard lived only in `.git/hooks/commit-msg`, which is local and lost on re-clone. This moves it into a versioned `.githooks/` directory and wires activation through Gradle.

## How it works

- **`.githooks/commit-msg`** (committed, executable) — rejects any commit whose message contains an automated AI-attribution footer, keeping commits under the human developer's identity.
- **Gradle `installGitHooks` task** (root `build.gradle.kts`) — runs `git config core.hooksPath .githooks`, guarded by `onlyIf { .git exists }`.
- **Wired into every module's `build` / `check`** — so the first `./gradlew build` after a clone re-points `core.hooksPath` automatically. No manual step required.

## Verified

- Hook rejects a message with an attribution footer; passes a clean message.
- Simulated fresh clone: unset `core.hooksPath`, ran `./gradlew installGitHooks`, confirmed it was restored to `.githooks`.
- This very PR's commit passed through the active hook.

## Manual fallback

If someone clones and never runs Gradle, they can activate it once with:

```
git config core.hooksPath .githooks
```