### PR TITLE
fix(ci): repair Common+KSP job and iOS 18 Xcode pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
           ./gradlew :kmpworker:check
           -x :kmpworker:connectedAndroidTest
           -x :kmpworker:iosX64Test
-          -x :kmpworker:iosArm64Test
           -x :kmpworker:iosSimulatorArm64Test
       - name: KSP processor tests
         run: ./gradlew :kmpworker-ksp:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             xcode: "15.4"
           - runtime: "iOS 18"
             device: "iPhone 15 Pro"
-            xcode: "16.0"
+            xcode: "16.2"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Two independent CI breakages, both unrelated to any product code.

## 1. Common + KSP unit tests — bogus task exclusion

```
Cannot locate excluded tasks that match ':kmpworker:iosArm64Test'
as task 'iosArm64Test' is ambiguous in project ':kmpworker'.
```

`:kmpworker:check` was run with `-x :kmpworker:iosArm64Test`, but no such task exists — `iosArm64` is a device target and KMP generates no runnable unit-test task for it (only `iosX64Test` and `iosSimulatorArm64Test` exist). Gradle 8.14 treats an unresolvable `-x` as a hard error, failing the job before any test runs.

**Fix:** drop the bogus exclusion. The remaining three are real tasks.

**Verified locally:** `./gradlew :kmpworker:check -x …connectedAndroidTest -x …iosX64Test -x …iosSimulatorArm64Test` → BUILD SUCCESSFUL.

## 2. iOS 18 job — non-existent Xcode

The iOS 18 row selected `/Applications/Xcode_16.0.app`, absent on the macos-14 runner → `xcode-select: invalid developer directory`, job dies in ~10s.

Per the actions/runner-images macos-14 manifest, the runner ships **Xcode 16.2 and 16.1** (no 16.0), with iOS 18.1/18.2 simulator runtimes. Pinned to **16.2** (newest available), keeping the explicit-pin approach.

## Still out of scope (separate infra issues)

- `Android instrumented (API 28–35)` emulator failures.
- iOS 16/17 flakiness.