### PR TITLE
fix(ios): queue-counter double-count (the real flaky-test root cause)

### DIFF
--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -319,28 +319,24 @@ public class IosFileStorage(
 
     init {
         backgroundScope.launch {
-            // Initialize queue size counters from actual queue size on disk.
-            // This ensures the counter is accurate after app restart.
+            // NOTE: the queue-size counters are deliberately NOT eagerly initialized here.
             //
-            // CAS-from-UNINITIALIZED (not an unconditional write): this background job
-            // runs on Dispatchers.Default and races with enqueueTask/dequeueTask, which
-            // lazily initialize and then mutate the same counters under enqueueTasksMutex.
-            // An unconditional `counter.value = diskSize` here would clobber a value that
-            // a concurrent enqueue already set — e.g. enqueue sets the tasks counter to 1
-            // and writes the item to disk, then this job (having read disk as 0 a moment
-            // earlier) resets the counter to 0. getTasksQueueSize() would then report an
-            // empty queue, the dispatcher would skip the task, and its metadata would never
-            // be dropped. Only initialize when no enqueue/dequeue has touched the counter yet.
-            val actualQueueSize = queue.getSize()
-            if (queueSizeCounter.compareAndSet(UNINITIALIZED_COUNTER, actualQueueSize)) {
-                Logger.d(LogTags.SCHEDULER, "Initialized chain queue size counter: $actualQueueSize")
-            }
-
-            val actualTasksQueueSize = tasksQueue.getSize()
-            if (tasksQueueSizeCounter.compareAndSet(UNINITIALIZED_COUNTER, actualTasksQueueSize)) {
-                Logger.d(LogTags.SCHEDULER, "Initialized tasks queue size counter: $actualTasksQueueSize")
-            }
-
+            // This background job runs on Dispatchers.Default and would otherwise race with
+            // enqueueTask, which is non-atomic across its disk write and its counter update:
+            // enqueueTask appends to the queue file FIRST, then decides whether to seed the
+            // counter from disk (when UNINITIALIZED) or incrementAndGet() (when already set).
+            // If this job read the queue size in that window — after the append but before
+            // enqueueTask updated the counter — it would seed the counter to the new disk
+            // size (already counting the appended item); enqueueTask would then take the
+            // "else" branch and increment again, double-counting that item (counter = N+1
+            // for N items on disk). getTasksQueueSize() then over-reports by one, and the
+            // dispatcher / FIFO / retry-cap assertions fail intermittently (observed as a
+            // flaky 5-test cluster on loaded CI runners, never locally).
+            //
+            // Eager initialization is redundant anyway: enqueueTask and getTasksQueueSize
+            // both lazily seed the counter from disk on first use when it is UNINITIALIZED,
+            // and dequeueTask is a no-op on the counter while UNINITIALIZED. Removing the
+            // only concurrent writer makes the counter math deterministic.
             val hoursSinceLastMaintenance = getHoursSinceLastMaintenance()
 
             if (hoursSinceLastMaintenance >= 24) {


### PR DESCRIPTION
Follow-up to #37. The race fix in #37 did **not** stop the flakiness — the iOS HTML report from a failing run revealed the actual cause and direction.

## What actually failed

A **5-test cluster**, all asserting queue size **+1 too high** (not the "reset to 0" I first theorized):

| Test | Assertion |
|---|---|
| `IosDynamicTaskDispatcherTest` — tasks queue FIFO | `Expected <3>, actual <4>` |
| `BugFixes_v243_IosTest` — routing to master dispatcher | `Expected <1>, actual <2>` |
| `IosStorageStressTest` — zero-length/large payloads | queue size off by one |
| `V250DynamicRetryTest.retry_respectsAttemptCap_dropsAfterCap` | `Expected <0>, actual <1>` |
| `V250DynamicRetryTest.success_dropsMetadata_underConstructEnqueueRace` (the #37 amplifier) | `Expected <0>, actual <1>` |

All touch `tasksQueueSizeCounter`. Intermittent, loaded-CI-only (iOS 16 passed the same run; #34's run passed all).

## Root cause

`enqueueTask` is non-atomic across its disk write and its counter update — it **appends to the queue file first**, then decides to seed the counter from disk (when `UNINITIALIZED`) or `incrementAndGet()`. The init block's background job (Dispatchers.Default) read the queue size **in that window** — after the append, before `enqueueTask` updated the counter — and seeded the counter to the new disk size (already counting the appended item). `enqueueTask` then took the else-branch and incremented **again** → `counter = N+1`.

`#37`'s `compareAndSet` didn't fix it: the bug is enqueue's check-then-increment racing with *any* concurrent init, not a clobber.

## Fix

Remove the eager counter initialization from the init block entirely. It is **redundant** — `enqueueTask` and `getTasksQueueSize` already lazily seed the counter from disk on first use, and `dequeueTask` is a no-op while `UNINITIALIZED`. Removing the only concurrent writer makes the counter deterministic. Maintenance scheduling is unchanged.

## Verification

- Full `iosSimulatorArm64Test` suite green locally (5m14s); the 5 tests green across repeated local runs.
- **Honest caveat:** the flake never reproduced on local Apple Silicon, so local green is not proof. The fix rests on the code-level race analysis (now matched to the exact `+1` symptom from the HTML report). The iOS jobs on this PR — run a few times — are the empirical confirmation.

## Note on #37

#37's `compareAndSet` is now superseded (the eager init it guarded is gone). Its amplifier test `success_dropsMetadata_underConstructEnqueueRace` is kept — it caught this real bug on CI.