### PR TITLE
feat(ios): real network reachability via NWPathMonitor (closes #40)

### DIFF
--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/IosNetworkReachability.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/IosNetworkReachability.kt
@@ -1,0 +1,59 @@
+package dev.brewkits.kmpworkmanager.background.domain
+
+import kotlin.concurrent.AtomicInt
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.darwin.dispatch_get_global_queue
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+
+/**
+ * Real network reachability for iOS, backed by `NWPathMonitor` (Network.framework, iOS 12+).
+ *
+ * Replaces the previous hardcoded `checkNetworkReachability() = true` placeholder
+ * (issue #40). A single process-wide monitor runs on a background GCD queue and updates
+ * [snapshot] whenever the OS reports a path change; [isReachable] reads that snapshot —
+ * a non-blocking O(1) call suitable for the synchronous diagnostics path.
+ *
+ * Self-contained: no Swift bridge required. Until the monitor delivers its first update,
+ * [isReachable] returns `true` (conservative — matches the old placeholder's optimism so
+ * a not-yet-warmed monitor never spuriously reports "offline").
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal object IosNetworkReachability {
+
+    // 1 = reachable, 0 = not reachable. Seeded to 1 (see KDoc).
+    private val reachable = AtomicInt(1)
+
+    private val monitor by lazy {
+        nw_path_monitor_create().also { m ->
+            nw_path_monitor_set_update_handler(m) { path ->
+                val satisfied = nw_path_get_status(path) == nw_path_status_satisfied
+                reachable.value = if (satisfied) 1 else 0
+            }
+            nw_path_monitor_set_queue(m, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u))
+            nw_path_monitor_start(m)
+        }
+    }
+
+    /**
+     * Snapshot of current reachability. Starts the monitor lazily on first call.
+     *
+     * In a test environment the monitor is NOT started: NWPathMonitor's update handler
+     * fires on a background GCD queue and outlives the per-class test process teardown,
+     * which Kotlin/Native surfaces as a process-level crash unattributed to any test
+     * (it made the whole iosSimulatorArm64Test run flaky). Tests get the conservative
+     * `true` seed instead. Detection mirrors [IosFileCoordinator]'s test-env short-circuit.
+     */
+    fun isReachable(): Boolean {
+        if (dev.brewkits.kmpworkmanager.utils.IosTestEnvironment.isTestEnvironment) {
+            return reachable.value == 1
+        }
+        monitor // touch to start lazily
+        return reachable.value == 1
+    }
+}

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/IosWorkerDiagnostics.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/IosWorkerDiagnostics.kt
@@ -68,7 +68,7 @@ internal class IosWorkerDiagnostics(
         val freeSpace = fileStorage.getAvailableDiskSpace()
         val isStorageLow = freeSpace < 500_000_000L // <500MB
 
-        // Network check: conservatively returns true (NWPathMonitor requires Swift interop)
+        // Network check via NWPathMonitor (see IosNetworkReachability / issue #40).
         val networkAvailable = checkNetworkReachability()
 
         return SystemHealthReport(
@@ -128,11 +128,11 @@ internal class IosWorkerDiagnostics(
     }
 
     /**
-     * Network reachability check.
-     * Returns true conservatively — NWPathMonitor requires Swift interop to implement properly.
-     * For accurate network state, pass the result from Swift via your app's bridge layer.
+     * Network reachability via [IosNetworkReachability] (NWPathMonitor, Network.framework).
+     * Non-blocking snapshot read; returns `true` until the monitor delivers its first
+     * path update (conservative warm-up, matching the prior placeholder's optimism).
      */
-    private fun checkNetworkReachability(): Boolean = true
+    private fun checkNetworkReachability(): Boolean = IosNetworkReachability.isReachable()
 
     private fun nowMillis(): Long {
         return (NSDate().timeIntervalSince1970 * 1000).toLong()

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosNetworkReachabilityTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosNetworkReachabilityTest.kt
@@ -1,0 +1,31 @@
+package dev.brewkits.kmpworkmanager
+
+import dev.brewkits.kmpworkmanager.background.domain.IosNetworkReachability
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Covers the reachability helper that replaced the `checkNetworkReachability() = true`
+ * placeholder (issue #40).
+ *
+ * Note: in a test environment [IosNetworkReachability.isReachable] deliberately does NOT
+ * start NWPathMonitor — its background update handler outlives the test process and made
+ * the whole iOS suite flaky. So under test it always returns the conservative `true` seed.
+ * The production NWPathMonitor path is exercised on-device, not here. These tests pin the
+ * contract that the call is synchronous, non-throwing, and safe to call repeatedly.
+ */
+class IosNetworkReachabilityTest {
+
+    @Test
+    fun isReachable_isNonBlockingAndDoesNotThrow() {
+        // Must return synchronously without throwing (cinterop wiring is the fragile part).
+        assertTrue(IosNetworkReachability.isReachable(), "test-env snapshot is the `true` seed")
+    }
+
+    @Test
+    fun isReachable_isStableAcrossRepeatedCalls() {
+        repeat(50) {
+            assertTrue(IosNetworkReachability.isReachable(), "repeated calls must stay stable and not throw")
+        }
+    }
+}


### PR DESCRIPTION
Implements #40.

## What changed

`IosWorkerDiagnostics.checkNetworkReachability()` was a hardcoded `= true` placeholder. It now reports real connectivity via a new `IosNetworkReachability` backed by **NWPathMonitor** (Network.framework, iOS 12+; project min is iOS 15).

- A process-wide monitor runs on a background GCD queue and updates an atomic snapshot on every path change.
- `isReachable()` reads that snapshot — non-blocking O(1), safe for the synchronous diagnostics path.
- Self-contained: **no Swift bridge required** (option 1 from the issue).
- Warm-up: returns `true` until the first path update lands (conservative, matches the old placeholder's optimism).

## Test-environment guard (important)

`isReachable()` deliberately does **not** start NWPathMonitor under `IosTestEnvironment.isTestEnvironment`. The monitor's update handler fires on a background queue that outlives per-class test teardown, which Kotlin/Native surfaces as a process-level crash **unattributed to any test** — in practice it made the whole `iosSimulatorArm64Test` run intermittently fail (verified: identical code went FAILED then SUCCESSFUL on reruns). Under test we return the seed; the production monitor path runs on-device. This mirrors `IosFileCoordinator`'s existing test-env short-circuit.

## Verification

- `IosNetworkReachabilityTest` pins the contract: synchronous, non-throwing, stable across repeated calls.
- **Full `iosSimulatorArm64Test` suite green across 3 consecutive local runs** (862 tests, 0 failures each) — confirming the flakiness this could have introduced is gone.

## Note

`getAvailableDiskSpace()` in the same file was already a real implementation (NSFileManager) — only reachability was stubbed.