### PR TITLE
fix(ios): stop maintenance auto-launch crashing test jobs (closes #42)

### DIFF
--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -318,6 +318,16 @@ public class IosFileStorage(
     }
 
     init {
+        // Skip the auto-launched maintenance job in test environments. It runs on
+        // backgroundScope (Dispatchers.Default) and, for a fresh temp dir, sees
+        // "maintenance never run" → executes performMaintenanceTasks() immediately,
+        // which logs and writes files. When the test that constructed this storage has
+        // already finished (and didn't await close(), or close() raced the launch), that
+        // output arrives after teardown — Kotlin/Native's test runner reports it as
+        // "Received output for test that is not running" and the whole job crashes
+        // (issue #42). Tests that need maintenance call performMaintenanceTasks() directly,
+        // so gating only the auto-launch costs no coverage. Production is unaffected.
+        if (!dev.brewkits.kmpworkmanager.utils.IosTestEnvironment.isTestEnvironment) {
         backgroundScope.launch {
             // NOTE: the queue-size counters are deliberately NOT eagerly initialized here.
             //
@@ -349,6 +359,7 @@ public class IosFileStorage(
                 delay(5000)
                 performMaintenanceTasks()
             }
+        }
         }
     }
 


### PR DESCRIPTION
Fixes #42 — the intermittent iOS-CI crash that forced job reruns on nearly every PR this cycle (#34, #37, #38, #41).

## Root cause (now pinned)

The crash is not a test assertion; it's a harness-level failure:

```
java.lang.IllegalStateException: Received output for test that is not running:
  Test externalTruncate_stillTriggersFullReset (AppendOnlyQueueCrcCorruptionTest)
java.util.ConcurrentModificationException
```

`IosFileStorage.init` launches a maintenance job on `backgroundScope` (Dispatchers.Default). Every test uses a fresh temp dir, so the job sees "maintenance never run" and runs `performMaintenanceTasks()` **immediately** — which logs and writes files. When the test that constructed the storage has already finished (and didn't await `close()`, or `close()` raced the launch), that output arrives **after teardown**. Kotlin/Native's test runner reports it as "Received output for test that is not running" and fails the whole job. Reruns pass, so it presented as flakiness.

## Fix

Gate the auto-launch behind `IosTestEnvironment.isTestEnvironment` — the same detector already used by `IosFileCoordinator` and `IosNetworkReachability` (#41). Tests that exercise maintenance call `performMaintenanceTasks()` / `getHoursSinceLastMaintenance()` **directly**, so gating only the implicit auto-launch costs no coverage. Production scheduling is unchanged.

## Verification

- Maintenance tests (`BugFixes_v240_IosTest`, `BugFixes_v238_IosTest`, `ExistingPolicyTest`) still pass.
- Full `iosSimulatorArm64Test` suite green across **3 consecutive local runs** (862 tests, 0 failures each).
- The flake is loaded-CI-only and rare, so local green isn't full proof — but the leak source is now removed at the root, not worked around. The iOS CI jobs on this PR are the confirmation.