### PR TITLE
chore: guard risky Dependabot bumps + fix Kotlin badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,18 @@ updates:
           - "org.jetbrains.compose*"
           - "org.jetbrains.compose.*"
     ignore:
-      # Pin Kotlin to whatever the project sets in libs.versions.toml. Major
-      # Kotlin bumps require coordinated KGP / KSP / Compose updates and should
-      # be manual PRs, not Dependabot one-liners.
+      # Kotlin in a KMP project requires coordinated KGP / KSP / Compose-compiler
+      # bumps — even a MINOR Kotlin bump (e.g. 2.1 -> 2.4) can break the build.
+      # Keep these manual; ignore both major and minor (patch updates still flow).
       - dependency-name: "org.jetbrains.kotlin:*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # KSP version is pinned to the Kotlin version (e.g. 2.1.21-2.0.1); a major
+      # KSP bump implies a Kotlin bump — handle alongside Kotlin, manually.
+      - dependency-name: "com.google.devtools.ksp:*"
+        update-types: [ "version-update:semver-major" ]
+      # Ktor majors are migrations, not one-liners (2 -> 3 was a whole release).
+      # Patch/minor still flow through the grouped PR for review.
+      - dependency-name: "io.ktor:*"
         update-types: [ "version-update:semver-major" ]
       # AGP majors break Gradle compatibility — handle manually.
       - dependency-name: "com.android.tools.build:gradle"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # KMP WorkManager
 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.brewkits/kmpworkmanager?color=7C3AED&label=Maven%20Central)](https://central.sonatype.com/artifact/dev.brewkits/kmpworkmanager)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.0-7C3AED?logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.21-7C3AED?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![CI](https://github.com/brewkits/kmpworkmanager/actions/workflows/build.yml/badge.svg)](https://github.com/brewkits/kmpworkmanager/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue)](LICENSE)
 


### PR DESCRIPTION
Follow-up housekeeping after the v3.0.0 release.

## Dependabot guards (`.github/dependabot.yml`)

The 8 stale Dependabot PRs we just closed included two that should never be one-line auto-bumps in a KMP project — this tightens the `ignore` rules so they don't come back as noise:

- **Kotlin** — now ignore **minor** bumps too (was major-only). A minor Kotlin bump (e.g. `2.1 → 2.4`) needs coordinated KGP / KSP / Compose-compiler updates; keep it a manual PR. Patch updates still flow.
- **KSP** — ignore major bumps (its version tracks Kotlin's, e.g. `2.1.21-2.0.1`).
- **Ktor** — ignore major bumps. A Ktor major is a migration (the `2 → 3` work was a whole release), not a one-liner. Patch/minor still flow through the grouped PR for review.

AGP-major ignore is unchanged.

## README

Kotlin badge said `2.1.0` but the toolchain is `2.1.21` — corrected. (The Maven Central badge is dynamic and already shows `3.0.0`.)

No code changes.