### PR TITLE
fix(release): checksum verify allows extra checksums (unblocks release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,12 @@ jobs:
             echo "::error::artifact count ($ARTIFACTS) != signature count ($SIGNATURES) — signing did not cover every artifact"
             exit 1
           fi
-          if [ "$ARTIFACTS" -ne "$MD5S" ] || [ "$ARTIFACTS" -ne "$SHA1S" ]; then
-            echo "::error::checksums missing — every artifact must have .md5 and .sha1 (Sonatype Central requirement)"
+          # Every artifact must carry .md5 + .sha1, but the bundle also checksums
+          # non-"artifact" files (maven-metadata.xml, etc.), so the checksum count is
+          # legitimately HIGHER than the artifact count. Fail only when checksums are
+          # MISSING (fewer than artifacts), not when there are extras.
+          if [ "$MD5S" -lt "$ARTIFACTS" ] || [ "$SHA1S" -lt "$ARTIFACTS" ]; then
+            echo "::error::checksums missing — every artifact must have .md5 and .sha1 (Sonatype Central requirement). artifacts=$ARTIFACTS md5=$MD5S sha1=$SHA1S"
             exit 1
           fi
 


### PR DESCRIPTION
First time the release workflow got past signing (after the SIGNING_KEY_BASE64 secret was corrected), the **Verify bundle** step failed:

```
Artifacts: 92,  MD5: 200,  SHA1: 200
::error::checksums missing — every artifact must have .md5 and .sha1
```

The check required exact equality (`ARTIFACTS -ne MD5S`), but `generateFullMavenZip` checksums **every** file (including `maven-metadata.xml` and other non-artifact files), so the checksum count is legitimately higher than the artifact count. Signing itself is correct (92 artifacts × 92 `.asc`).

Fix: fail only when checksums are **missing** (fewer than artifacts), not when extras are present. Latent bug — surfaced only now because this is the first release run to clear signing.