### PR TITLE
chore: v3.0.1 pre-publish hardening (CI getForegroundInfo guard + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 ```kotlin
 // build.gradle.kts
 commonMain.dependencies {
-    implementation("dev.brewkits:kmpworkmanager:3.0.0")          // core engine (no Ktor)
+    implementation("dev.brewkits:kmpworkmanager:3.0.1")          // core engine (no Ktor)
     // Optional — only if you use the built-in HTTP workers (Http*/ParallelHttp*).
-    implementation("dev.brewkits:kmpworkmanager-http:3.0.0")     // Ktor 3 HTTP workers
+    implementation("dev.brewkits:kmpworkmanager-http:3.0.1")     // Ktor 3 HTTP workers
 }
 ```
 
@@ -428,8 +428,8 @@ Add to `build.gradle.kts`:
 plugins { id("com.google.devtools.ksp") }
 
 dependencies {
-    ksp("dev.brewkits:kmpworker-ksp:3.0.0")
-    commonMain.implementation("dev.brewkits:kmpworker-annotations:3.0.0")
+    ksp("dev.brewkits:kmpworker-ksp:3.0.1")
+    commonMain.implementation("dev.brewkits:kmpworker-annotations:3.0.1")
 }
 ```
 

--- a/docs/BUILTIN_WORKERS_GUIDE.md
+++ b/docs/BUILTIN_WORKERS_GUIDE.md
@@ -622,8 +622,8 @@ engine stays Ktor-free. Add it only if you use `Http*` / `ParallelHttp*` workers
 
 ```kotlin
 commonMain.dependencies {
-    implementation("dev.brewkits:kmpworkmanager:3.0.0")        // core engine (no Ktor)
-    implementation("dev.brewkits:kmpworkmanager-http:3.0.0")   // HTTP workers (Ktor 3)
+    implementation("dev.brewkits:kmpworkmanager:3.0.1")        // core engine (no Ktor)
+    implementation("dev.brewkits:kmpworkmanager-http:3.0.1")   // HTTP workers (Ktor 3)
 }
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -36,7 +36,7 @@ Could not find dev.brewkits:kmpworkmanager:2.3.2
 
 2. Check version number is correct:
    ```kotlin
-   implementation("dev.brewkits:kmpworkmanager:3.0.0") // Latest
+   implementation("dev.brewkits:kmpworkmanager:3.0.1") // Latest
    ```
 
 3. Clear Gradle cache:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,10 +21,10 @@ Add KMP WorkManager to your `build.gradle.kts` (module level):
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.brewkits:kmpworkmanager:3.0.0")
+            implementation("dev.brewkits:kmpworkmanager:3.0.1")
             // Optional — only if you use the built-in HTTP workers (Http*/ParallelHttp*).
             // Requires Ktor 3; see docs/MIGRATION_V3.0.0.md.
-            implementation("dev.brewkits:kmpworkmanager-http:3.0.0")
+            implementation("dev.brewkits:kmpworkmanager-http:3.0.1")
         }
     }
 }

--- a/kmpworker/build.gradle.kts
+++ b/kmpworker/build.gradle.kts
@@ -120,6 +120,9 @@ android {
 
     testOptions {
         unitTests.isReturnDefaultValues = true
+        // Let Robolectric load merged Android resources (e.g. the worker notification
+        // strings used by KmpWorker.getForegroundInfo()) in JVM unit tests.
+        unitTests.isIncludeAndroidResources = true
     }
 }
 

--- a/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpWorkerForegroundInfoTest.kt
+++ b/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpWorkerForegroundInfoTest.kt
@@ -1,0 +1,66 @@
+package dev.brewkits.kmpworkmanager.background.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorker
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorkerFactory
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * CI-level (Robolectric, no emulator) regression net for the API < 31 expedited crash.
+ *
+ * The scheduler marks immediate non-heavy tasks `setExpedited(...)`. On API < 31 an
+ * expedited request runs as a foreground service, so WorkManager calls
+ * [KmpWorker.getForegroundInfo]. If the override is missing (as it was after the
+ * BaseKmpWorker extraction in 1d8135b), the default [androidx.work.CoroutineWorker]
+ * implementation throws `IllegalStateException("Not implemented")` and the worker crashes.
+ *
+ * The instrumented [dev.brewkits.kmpworkmanager.KmpWorkerForegroundInfoCompatTest] also
+ * covers this, but only runs on a device/emulator. This unit test runs in plain
+ * `testDebugUnitTest` so the regression can never slip through CI again. Pinned to
+ * `sdk = 30` (Android 11, API < 31) — the exact range the bug affected.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class KmpWorkerForegroundInfoTest {
+
+    private object NoopAndroidFactory : AndroidWorkerFactory {
+        override fun createWorker(workerClassName: String): AndroidWorker? = null
+    }
+
+    /** Factory that builds the real KmpWorker via its DI constructor (no Koin needed). */
+    private class TestFactory : WorkerFactory() {
+        override fun createWorker(
+            appContext: Context,
+            workerClassName: String,
+            workerParameters: WorkerParameters
+        ): ListenableWorker = KmpWorker(appContext, workerParameters, NoopAndroidFactory)
+    }
+
+    @Test
+    fun getForegroundInfo_returnsValidNotification_doesNotThrowNotImplemented() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val worker = TestListenableWorkerBuilder<KmpWorker>(context)
+            .setWorkerFactory(TestFactory())
+            .build()
+
+        // The crux: the default CoroutineWorker.getForegroundInfo() throws
+        // IllegalStateException("Not implemented"). Reaching a non-null ForegroundInfo
+        // proves KmpWorker overrides it.
+        val info = runBlocking { worker.getForegroundInfo() }
+
+        assertNotNull(info, "KmpWorker must override getForegroundInfo() (regression: API < 31 expedited crash)")
+        assertNotNull(info.notification, "ForegroundInfo must carry a fallback notification")
+        assertTrue(info.notificationId != 0, "notificationId must be set")
+    }
+}


### PR DESCRIPTION
Pre-publish hardening for **v3.0.1**, verified on real devices.

## Tests
- **New `KmpWorkerForegroundInfoTest`** (Robolectric, `sdk=30`) — asserts `KmpWorker.getForegroundInfo()` returns a valid `ForegroundInfo` instead of the default `CoroutineWorker` `Not implemented` throw. The instrumented `KmpWorkerForegroundInfoCompatTest` only runs on a device/emulator; this gives a **CI-level** guard for the API<31 expedited regression so it can never slip through plain CI again.
- Enable `testOptions.unitTests.isIncludeAndroidResources` so Robolectric can load the worker notification strings `getForegroundInfo()` reads. Full `:kmpworker:testDebugUnitTest` stays green.

## Docs
- Bump install snippets **3.0.0 → 3.0.1** in README, quickstart, BUILTIN_WORKERS_GUIDE, TROUBLESHOOTING. Historical/migration docs left untouched.

## Real-device verification
- **Android (Pixel 6 Pro, real):** demo installs, launches, schedules a one-time task → `UploadWorker` runs to 100MB → `success=true duration=3062ms`, `WM-WorkerWrapper: SUCCESS`.
- **iOS (iPhone XS Max, iOS 18.7.9, real):** demo installs, launches, `BGTask Registration completed (37 tasks)`, NSUserDefaults→file storage migration successful, no crash.

All test suites green on Gradle 9 (iOS sim + Android unit + KSP).