### PR TITLE
build(android): drop koin-android, declare androidx.core directly

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -271,12 +271,9 @@ v2.6 polishes the rough edges that surface during on-call.
 - ⏳ Profile maps to `Constraints` + `TaskPriority` so existing API stays
   source-compatible.
 
-### 5. DI-agnostic init
-- ⏳ Replace internal Koin dependency with a private `ServiceLocator` that
-  consumers can populate without bringing Koin into their classpath. Koin
-  module stays as an opt-in convenience.
-- ⏳ Provide a Hilt-friendly `KmpWorkManagerHiltModule` for Android consumers
-  who already use Hilt.
+### 5. DI-agnostic init — 🚧 moved to its own milestone
+Promoted out of v2.6 and rescoped after [discussion #66](https://github.com/brewkits/kmpworkmanager/discussions/66).
+See [v3.3 — DI-agnostic init](#v33--di-agnostic-init-koin-removal) below.
 
 ### 6. Flutter parity — Group 2 built-in workers
 - ⏳ **HMAC-SHA256 request signing** (`request_signing.dart` parity) —
@@ -298,6 +295,66 @@ v2.6 polishes the rough edges that surface during on-call.
   `deflate()` for O(1) RAM footprint. Output passes PKZIP local-header magic (`0x04034b50`)
   and EOCD signature checks. `allowIosUncompressedFallback` deprecated and ignored.
   `FileCompressionWorker` is now **Stable on both platforms**.
+
+---
+
+## v3.3 — DI-agnostic init (Koin removal)
+
+**Theme:** a background-task library should not force a DI framework onto its
+consumers. Raised by an outside library author in
+[discussion #66](https://github.com/brewkits/kmpworkmanager/discussions/66); the
+complaint is correct on the facts — `koin-core:4.0.0` ships at `runtime` scope in
+the published `.pom`/`.module` for the root, `-android` and all three iOS variants,
+so consumers who never touch Koin still carry it.
+
+**Where the coupling actually is (audited at 3.2.0):**
+- **Android** is already Koin-free at the API surface. `KmpWorkManager.initialize()`
+  exposes no Koin types; behind it sits a *private* `koinApplication {}` (never
+  `startKoin` / `GlobalContext`), covered by `KoinIsolationTest`. The Koin-exposing
+  `kmpWorkerModule()` overload has been `@Deprecated` since 2.2.2.
+- **iOS** is genuinely coupled. `kmpWorkerModule()` is the only documented iOS init
+  path, and it is declared in commonMain as
+  `expect fun kmpWorkerModule(...): org.koin.core.module.Module` — a public function
+  returning a type from an `implementation`-scoped dependency, which forces consumers
+  to declare koin-core themselves just to call it.
+- The entire koin-core surface is 5 files: `KoinModule.kt`, `KoinModule.android.kt`,
+  `KoinModule.ios.kt`, `KmpWorkManagerKoin.kt` (+ `KoinIsolationTest.kt`).
+- `KoinModule.ios.kt` uses **no** DI-container feature — no scopes, qualifiers,
+  `parametersOf`, or lazy graph. Everything meaningful (logger config,
+  `KmpWorkManagerRuntime.configure`, the `IosWorkerFactory` type check, the Info.plist
+  `BGTaskSchedulerPermittedIdentifiers` validation) runs at module-*construction* time,
+  and all six wired classes are already public. Extraction is mechanical.
+
+### Step 1 — patch (3.2.1) — ✅ done
+- ✅ Dropped `koin-android`. No production code in `androidMain` imports
+  `org.koin.android.*`; the dependency was only surviving because it transitively
+  supplied `androidx.core` (`NotificationCompat` in `KmpWorker` / `KmpHeavyWorker`).
+  `androidx.core:core-ktx` is now declared directly, and `koin-android` moved to the
+  `androidInstrumentedTest` source set where `KoinIsolationTest` actually uses it.
+  `kmpworkmanager-android`'s POM now carries only `koin-core-jvm`.
+
+### Step 2 — minor (3.3.0)
+- ⏳ Replace the internal private `koinApplication` with a plain internal
+  `ServiceRegistry`. Touches the 5 bindings, the 3 service-locator call sites
+  (`BaseKmpWorker.kt:52`, `KmpWorker.kt:32`, `KmpHeavyWorker.kt:43`) and the
+  `internal constructor(Koin)` of the public `KmpWorkManagerInstance`.
+- ⏳ Add a Koin-free `KmpWorkManager.initialize(workerFactory, config, iosTaskIds)`
+  on iOS, mirroring the Android entry point.
+- ⏳ Move `kmpWorkerModule()` into an optional `kmpworkmanager-koin` artifact;
+  deprecate the copy in core.
+- ⏳ Provide a Hilt-friendly `KmpWorkManagerHiltModule` for Android consumers who
+  already use Hilt.
+- ⚠️ **koin-core still ships in core's POM after this step.** `kmpWorkerModule` is an
+  `expect fun` declared in core's commonMain whose iOS `actual` calls `module { }`, so
+  core keeps `implementation(koin-core)` for as long as that declaration lives there.
+  Deprecation does not remove a dependency.
+
+### Step 3 — major (4.0.0)
+- ⏳ Delete the deprecated `kmpWorkerModule()` from core. This — not step 2 — is the
+  point at which koin-core leaves the published metadata.
+- ⏳ `kmpWorkerModule()` must go through the full deprecation cycle rather than be
+  deleted outright: it is currently the only documented iOS init path, so removing it
+  early breaks every existing iOS consumer.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -333,28 +333,57 @@ so consumers who never touch Koin still carry it.
   `androidInstrumentedTest` source set where `KoinIsolationTest` actually uses it.
   `kmpworkmanager-android`'s POM now carries only `koin-core-jvm`.
 
-### Step 2 — minor (3.3.0)
+### Step 2 — minor (3.3.0) — the actual fix
+Removal and cleanup land together. A 3.3.0 that only *deprecated* `kmpWorkerModule()`
+would leave koin-core in core's POM — `kmpWorkerModule` is an `expect fun` declared in
+core's commonMain whose iOS `actual` calls `module { }`, so core keeps
+`implementation(koin-core)` for as long as that declaration lives there. Deprecation does
+not remove a dependency, and the POM is the thing consumers are complaining about. So the
+declaration goes in the same release.
+
 - ⏳ Replace the internal private `koinApplication` with a plain internal
   `ServiceRegistry`. Touches the 5 bindings, the 3 service-locator call sites
   (`BaseKmpWorker.kt:52`, `KmpWorker.kt:32`, `KmpHeavyWorker.kt:43`) and the
   `internal constructor(Koin)` of the public `KmpWorkManagerInstance`.
-- ⏳ Add a Koin-free `KmpWorkManager.initialize(workerFactory, config, iosTaskIds)`
-  on iOS, mirroring the Android entry point.
-- ⏳ Move `kmpWorkerModule()` into an optional `kmpworkmanager-koin` artifact;
-  deprecate the copy in core.
-- ⏳ Provide a Hilt-friendly `KmpWorkManagerHiltModule` for Android consumers who
-  already use Hilt.
-- ⚠️ **koin-core still ships in core's POM after this step.** `kmpWorkerModule` is an
-  `expect fun` declared in core's commonMain whose iOS `actual` calls `module { }`, so
-  core keeps `implementation(koin-core)` for as long as that declaration lives there.
-  Deprecation does not remove a dependency.
+  The registry must reproduce **both** resolution modes the Koin module relies on:
+  lazy singletons *and* eager ones — `IosEventStore`'s provider calls
+  `TaskEventManager.initialize(store)` as a resolution side effect, and Android's
+  `ExecutionHistoryStore` is deliberately `createdAtStart = true`. Getting this wrong
+  silently shifts `TaskEventManager` init timing. The iOS path must also preserve the
+  `migrationComplete` ordering documented in `CLAUDE.md`.
+- ⏳ Add a Koin-free `KmpWorkManager.initialize(workerFactory, config, iosTaskIds)` on
+  iOS, mirroring the Android entry point.
+- ⏳ Delete `kmpWorkerModule()` (and `kmpWorkerCoreModule()`) from core, plus the now
+  Koin-free `KoinModule*.kt` files. **koin-core leaves the published metadata here.**
+- ⏳ `docs/MIGRATION_V3.3.0.md` — the migration is ~4 lines in one file:
+  ```kotlin
+  // before
+  startKoin { modules(kmpWorkerModule(workerFactory = MyWorkerFactory())) }
+  // after
+  KmpWorkManager.initialize(workerFactory = MyWorkerFactory())
+  startKoin { modules(module { single { KmpWorkManager.getInstance().backgroundTaskScheduler } }) }
+  ```
+  Koin and Hilt users keep working via that snippet; it is documentation, not an artifact.
+- ⏳ Invariant test: the Koin-free init path must produce the *same wiring* as the Koin
+  module did — same instances, same eager/lazy timing — not merely compile.
+- ⏳ `KoinIsolationTest` loses its premise once there is no private Koin. Retire it, and
+  with it the `koin-android` test dependency added in step 1.
+- ⏳ Docs sweep: `README.md` (iOS setup, the primary offender), `KmpWorkManagerConfig.kt`
+  KDoc, `quickstart.md`, `platform-setup.md`, `examples.md`, `api-reference.md`,
+  `kmpworker-ksp/README.md`, and the `composeApp` iOS sample.
 
-### Step 3 — major (4.0.0)
-- ⏳ Delete the deprecated `kmpWorkerModule()` from core. This — not step 2 — is the
-  point at which koin-core leaves the published metadata.
-- ⏳ `kmpWorkerModule()` must go through the full deprecation cycle rather than be
-  deleted outright: it is currently the only documented iOS init path, so removing it
-  early breaks every existing iOS consumer.
+**Deliberately not doing:** a `kmpworkmanager-koin` bridge artifact, or a
+`KmpWorkManagerHiltModule`. Both were on the earlier version of this plan. Once
+`initialize()` exists, wrapping it in a Koin module or a Hilt `@Provides` is a
+three-line snippet in the consumer's own code; publishing a module × 4 targets × GPG
+signing × manual Central upload to save those three lines is a permanent maintenance
+cost for a one-time convenience.
+
+**Why a minor and not a major:** deleting a public API is a breaking change by strict
+semver, but this project has never held that line — v2.2.2, a *patch*, shipped "now
+requires WorkerFactory parameter" with `docs/MIGRATION_V2.2.2.md`. A major bump for a
+single dependency removal is a signal out of proportion to the work, and it would push
+the fix consumers are asking for further away for no benefit.
 
 ---
 

--- a/kmpworker/build.gradle.kts
+++ b/kmpworker/build.gradle.kts
@@ -53,8 +53,10 @@ kotlin {
             implementation(libs.androidx.work.runtime.ktx)
             // Coroutines support for Guava ListenableFuture
             implementation(libs.kotlinx.coroutines.guava)
-            // Koin for Android
-            implementation(libs.koin.android)
+            // NotificationCompat for the foreground-service notification in KmpWorker /
+            // KmpHeavyWorker. Declared explicitly — it used to arrive transitively via
+            // koin-android, which no production code in androidMain actually imports.
+            implementation(libs.androidx.core.ktx)
         }
 
         commonMain.dependencies {
@@ -89,6 +91,9 @@ kotlin {
             implementation(libs.androidx.work.runtime.ktx)
             implementation(libs.androidx.work.testing)
             implementation(libs.kotlinx.coroutines.test)
+            // KoinIsolationTest is the only consumer of koin-android in the project —
+            // it starts a host-app Koin to prove the library's private Koin stays isolated.
+            implementation(libs.koin.android)
         }
 
         val androidUnitTest by getting {


### PR DESCRIPTION
Follow-up to [discussion #66](https://github.com/brewkits/kmpworkmanager/discussions/66) — "Why Koin".

## What

Step 1 of the DI-agnostic init plan: remove `koin-android` from the published Android artifact.

- No production code in `androidMain` imports `org.koin.android.*` — every such import in the repo is in `androidInstrumentedTest/KoinIsolationTest.kt`.
- Removing the dependency initially broke the build with `Unresolved reference 'NotificationCompat'` in `KmpWorker.kt` / `KmpHeavyWorker.kt`: `koin-android` was silently supplying `androidx.core`. That is now declared directly as `androidx.core:core-ktx`.
- `koin-android` moved to the `androidInstrumentedTest` source set, where `KoinIsolationTest` genuinely needs it to start a host-app Koin and prove the library's private Koin stays isolated.

## Effect on published metadata

`kmpworkmanager-android` POM dependencies, before → after:

| | before | after |
|---|---|---|
| `io.insert-koin:koin-android` | present (runtime) | **gone** |
| `io.insert-koin:koin-core-jvm` | present (runtime) | present (runtime) |
| `androidx.core:core-ktx` | transitive | declared (runtime) |

`koin-core` still ships via commonMain. It comes off only when `kmpWorkerModule()` leaves core — deprecating it is not enough, since it is an `expect fun` declared in core's commonMain. Tracked as step 3 of the new roadmap milestone.

## Verification

- `:kmpworker:compileReleaseKotlinAndroid` — BUILD SUCCESSFUL
- `:kmpworker:compileDebugAndroidTestKotlinAndroid` — BUILD SUCCESSFUL
- `:kmpworker:compileReleaseUnitTestKotlinAndroid` — BUILD SUCCESSFUL
- `:kmpworker:generatePomFileForAndroidReleasePublication` — generated POM inspected, `koin-android` absent

## Also

`docs/ROADMAP.md`: "DI-agnostic init" was stale — filed under a `v2.6` heading while 3.2.0 has shipped. Promoted to its own `v3.3` milestone with the audited findings and a 3-step plan (patch / minor / major).