### PR TITLE
fix: KSP duplicate @Worker key detection + iOS path-traversal hardening

### DIFF
--- a/kmpworker-ksp/src/main/kotlin/dev/brewkits/kmpworkmanager/ksp/WorkerProcessor.kt
+++ b/kmpworker-ksp/src/main/kotlin/dev/brewkits/kmpworkmanager/ksp/WorkerProcessor.kt
@@ -93,14 +93,60 @@ class WorkerProcessor(
             }
         }
 
-        if (androidWorkers.isNotEmpty()) generateAndroidFactory(androidWorkers)
-        if (iosWorkers.isNotEmpty())     generateIosFactory(iosWorkers)
+        if (androidWorkers.isNotEmpty()) {
+            validateNoDuplicateKeys(androidWorkers, "Android")
+            generateAndroidFactory(androidWorkers)
+        }
+        if (iosWorkers.isNotEmpty()) {
+            validateNoDuplicateKeys(iosWorkers, "iOS")
+            generateIosFactory(iosWorkers)
+        }
 
         logger.info(
             "KmpWorker KSP: generated factories for " +
                 "${androidWorkers.size} Android + ${iosWorkers.size} iOS workers"
         )
         return emptyList()
+    }
+
+    /**
+     * Fails the build if two different `@Worker` classes claim the same factory key on the
+     * same platform — either two classes sharing an explicit or default `name`, or one
+     * worker's `aliases` colliding with another worker's `name`/`aliases`.
+     *
+     * Without this check, `generateAndroidFactory`/`generateIosFactory` emit
+     * `put(key) { ... }` once per (name + alias) entry into the same map; a second `put()`
+     * with the same key silently overwrites the first with no compile error and no KSP
+     * warning. One of the two workers becomes permanently unreachable at runtime — its
+     * tasks resolve to the *other* worker's implementation, or `createWorker()` returns the
+     * wrong instance. Since `@Worker(name = ...)` is documented as the stable identifier
+     * persisted tasks are looked up by, this is exactly the kind of collision this project
+     * has been burned by before (see `PendingIntentCodes` — String.hashCode() collisions
+     * splitting alarms across reboots).
+     *
+     * Reports every colliding key with all classes that claim it — the same class appearing
+     * twice for a key (e.g. `@Worker(name = "X", aliases = ["X"])`) is redundant, not
+     * harmful, and is not flagged.
+     */
+    internal fun validateNoDuplicateKeys(workers: List<WorkerInfo>, platform: String) {
+        val keyToClasses = mutableMapOf<String, MutableSet<String>>()
+        workers.forEach { worker ->
+            (listOf(worker.name) + worker.aliases).forEach { key ->
+                keyToClasses.getOrPut(key) { mutableSetOf() }.add(worker.className.canonicalName)
+            }
+        }
+        keyToClasses.forEach { (key, classes) ->
+            if (classes.size > 1) {
+                logger.error(
+                    "@Worker key \"$key\" ($platform) is claimed by multiple classes: " +
+                        "${classes.sorted().joinToString(", ")}. Each @Worker name and alias must " +
+                        "be unique per platform — the generated factory's providers map holds one " +
+                        "entry per key, so all but one of these workers would be silently " +
+                        "unreachable at runtime. Give each a distinct @Worker(name = ...) or " +
+                        "remove the colliding alias."
+                )
+            }
+        }
     }
 
     // ── Android factory ────────────────────────────────────────────────────────
@@ -295,7 +341,7 @@ private fun KSClassDeclaration.extendsWorkerType(
     return false
 }
 
-private data class WorkerInfo(
+internal data class WorkerInfo(
     val name: String,
     val className: ClassName,
     val bgTaskId: String,

--- a/kmpworker-ksp/src/test/kotlin/dev/brewkits/kmpworkmanager/ksp/WorkerProcessorDuplicateKeyTest.kt
+++ b/kmpworker-ksp/src/test/kotlin/dev/brewkits/kmpworkmanager/ksp/WorkerProcessorDuplicateKeyTest.kt
@@ -1,0 +1,140 @@
+package dev.brewkits.kmpworkmanager.ksp
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSNode
+import com.squareup.kotlinpoet.ClassName
+import org.junit.Test
+import java.io.OutputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [WorkerProcessor.validateNoDuplicateKeys] — the guard against two
+ * `@Worker` classes silently overwriting each other's entry in the generated
+ * `providers` map (discovered during a senior review pass, no prior coverage).
+ *
+ * **Why this bypasses [WorkerProcessorTest]'s compile-testing harness:** that entire
+ * class is `@Ignore`d — kctfork 0.6.0 never invokes [WorkerProcessor] for in-memory
+ * `SourceFile`s (see its class KDoc), so none of its 21 tests actually run in CI today.
+ * Rather than add a 22nd test to a harness that silently never executes, this calls
+ * [WorkerProcessor.validateNoDuplicateKeys] directly against synthetic [WorkerInfo]
+ * lists with a fake [KSPLogger] recording calls — exercising the real production
+ * method, just without going through full annotation processing. This test DOES run.
+ */
+class WorkerProcessorDuplicateKeyTest {
+
+    /** Records every `error()` call; the other [KSPLogger] methods are no-ops. */
+    private class RecordingLogger : KSPLogger {
+        val errors = mutableListOf<String>()
+        override fun logging(message: String, symbol: KSNode?) {}
+        override fun info(message: String, symbol: KSNode?) {}
+        override fun warn(message: String, symbol: KSNode?) {}
+        override fun error(message: String, symbol: KSNode?) { errors.add(message) }
+        override fun exception(e: Throwable) {}
+    }
+
+    /** [CodeGenerator] is never invoked by [WorkerProcessor.validateNoDuplicateKeys]. */
+    private class UnusedCodeGenerator : CodeGenerator {
+        override val generatedFile get() = emptySet<java.io.File>()
+        override fun associate(sources: List<com.google.devtools.ksp.symbol.KSFile>, packageName: String, fileName: String, extensionName: String) {}
+        override fun associateByPath(sources: List<com.google.devtools.ksp.symbol.KSFile>, path: String, extensionName: String) {}
+        override fun associateWithClasses(classes: List<com.google.devtools.ksp.symbol.KSClassDeclaration>, packageName: String, fileName: String, extensionName: String) {}
+        override fun createNewFile(dependencies: Dependencies, packageName: String, fileName: String, extensionName: String): OutputStream =
+            throw UnsupportedOperationException("not used by validateNoDuplicateKeys")
+        override fun createNewFileByPath(dependencies: Dependencies, path: String, extensionName: String): OutputStream =
+            throw UnsupportedOperationException("not used by validateNoDuplicateKeys")
+    }
+
+    private fun worker(name: String, className: String, aliases: List<String> = emptyList()) =
+        WorkerInfo(
+            name = name,
+            className = ClassName("dev.brewkits.test", className),
+            bgTaskId = "",
+            aliases = aliases
+        )
+
+    private fun processorWith(logger: RecordingLogger) = WorkerProcessor(UnusedCodeGenerator(), logger)
+
+    @Test
+    fun `distinct names produce no errors`() {
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(worker("SyncWorker", "SyncWorker"), worker("UploadWorker", "UploadWorker")),
+            "Android"
+        )
+        assertTrue(logger.errors.isEmpty(), "distinct names must not error, got: ${logger.errors}")
+    }
+
+    @Test
+    fun `two classes with the same explicit name is an error`() {
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(worker("SyncWorker", "FirstSyncWorker"), worker("SyncWorker", "SecondSyncWorker")),
+            "Android"
+        )
+        assertEquals(1, logger.errors.size, "exactly one collision must be reported, got: ${logger.errors}")
+        assertTrue(logger.errors[0].contains("SyncWorker"), "error must name the colliding key")
+        assertTrue(logger.errors[0].contains("FirstSyncWorker"), "error must name a colliding class")
+        assertTrue(logger.errors[0].contains("SecondSyncWorker"), "error must name the other colliding class")
+    }
+
+    @Test
+    fun `an alias colliding with another worker's canonical name is an error`() {
+        // The exact shape a dev could hit by accident: renaming SyncWorker to SyncWorkerV2
+        // with aliases = ["SyncWorker"] for backward compatibility, while a *different*,
+        // unrelated worker already happens to be named "SyncWorker".
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(
+                worker("SyncWorker", "LegacySyncWorker"),
+                worker("SyncWorkerV2", "SyncWorkerV2", aliases = listOf("SyncWorker"))
+            ),
+            "Android"
+        )
+        assertEquals(1, logger.errors.size)
+        assertTrue(logger.errors[0].contains("\"SyncWorker\""))
+    }
+
+    @Test
+    fun `two aliases colliding with each other is an error`() {
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(
+                worker("WorkerA", "WorkerA", aliases = listOf("OldName")),
+                worker("WorkerB", "WorkerB", aliases = listOf("OldName"))
+            ),
+            "iOS"
+        )
+        assertEquals(1, logger.errors.size)
+        assertTrue(logger.errors[0].contains("OldName"))
+        assertTrue(logger.errors[0].contains("iOS"), "platform must be identified in the message")
+    }
+
+    @Test
+    fun `the same class listing its own name as an alias is not an error`() {
+        // Redundant, not harmful — put(key){SameClass()} twice with the same class loses
+        // nothing. Only flag when DIFFERENT classes claim the same key.
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(worker("SyncWorker", "SyncWorker", aliases = listOf("SyncWorker"))),
+            "Android"
+        )
+        assertTrue(logger.errors.isEmpty(), "self-collision must not error, got: ${logger.errors}")
+    }
+
+    @Test
+    fun `multiple independent collisions are all reported`() {
+        val logger = RecordingLogger()
+        processorWith(logger).validateNoDuplicateKeys(
+            listOf(
+                worker("A", "ClassA1"), worker("A", "ClassA2"),
+                worker("B", "ClassB1"), worker("B", "ClassB2"),
+                worker("C", "ClassC1")
+            ),
+            "Android"
+        )
+        assertEquals(2, logger.errors.size, "both A and B collisions must be reported independently")
+    }
+}

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -688,7 +688,7 @@ public class IosFileStorage(
      * Save chain definition to file
      */
     fun saveChainDefinition(id: String, steps: List<List<TaskRequest>>) {
-        val chainFile = chainsDirURL.safeAppend("$id.json")
+        val chainFile = chainsDirURL.safeAppend("${id.encodeAsPathComponent()}.json")
         val json = Json.encodeToString(steps)
 
         // Use actual UTF-8 byte count, not String.length (UTF-16 char count).
@@ -716,7 +716,7 @@ public class IosFileStorage(
      * now `suspend` (must acquire `progressMutex` to evict the buffer entry).
      */
     suspend fun loadChainDefinition(id: String): List<List<TaskRequest>>? {
-        val chainFile = chainsDirURL.safeAppend("$id.json")
+        val chainFile = chainsDirURL.safeAppend("${id.encodeAsPathComponent()}.json")
 
         // The `coordinated` callback is a non-suspend block, so the suspend-only
         // `deleteChainProgress(id)` call has to happen AFTER coordination returns.
@@ -751,7 +751,7 @@ public class IosFileStorage(
      * Delete chain definition
      */
     fun deleteChainDefinition(id: String) {
-        val chainFile = chainsDirURL.safeAppend("$id.json")
+        val chainFile = chainsDirURL.safeAppend("${id.encodeAsPathComponent()}.json")
         deleteFile(chainFile)
         Logger.d(LogTags.CHAIN, "Deleted chain definition $id")
     }
@@ -760,7 +760,7 @@ public class IosFileStorage(
      * Check if chain definition exists
      */
     fun chainExists(id: String): Boolean {
-        val chainFile = chainsDirURL.safeAppend("$id.json")
+        val chainFile = chainsDirURL.safeAppend("${id.encodeAsPathComponent()}.json")
         val path = chainFile.path ?: return false
         return fileManager.fileExistsAtPath(path)
     }
@@ -773,7 +773,7 @@ public class IosFileStorage(
      *
      */
     fun markChainAsDeleted(chainId: String) {
-        val markerFile = deletedChainsDirURL.safeAppend("$chainId.marker")
+        val markerFile = deletedChainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}.marker")
         val timestamp = NSDate().timeIntervalSince1970.toLong()
 
         coordinated(markerFile, write = true) { safeUrl ->
@@ -789,7 +789,7 @@ public class IosFileStorage(
      *
      */
     fun isChainDeleted(chainId: String): Boolean {
-        val markerFile = deletedChainsDirURL.safeAppend("$chainId.marker")
+        val markerFile = deletedChainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}.marker")
         val path = markerFile.path ?: return false
         return fileManager.fileExistsAtPath(path)
     }
@@ -800,7 +800,7 @@ public class IosFileStorage(
      *
      */
     fun clearDeletedMarker(chainId: String) {
-        val markerFile = deletedChainsDirURL.safeAppend("$chainId.marker")
+        val markerFile = deletedChainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}.marker")
         deleteFile(markerFile)
         Logger.d(LogTags.CHAIN, "Cleared deleted marker for chain $chainId")
     }
@@ -1006,7 +1006,7 @@ public class IosFileStorage(
                 // call returns (the coordinator itself cannot be interrupted mid-call).
                 kotlinx.coroutines.currentCoroutineContext().ensureActive()
 
-                val progressFile = chainsDirURL.safeAppend("${chainId}_progress.json")
+                val progressFile = chainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}_progress.json")
                 val json = Json.encodeToString(progress)
 
                 try {
@@ -1166,7 +1166,7 @@ public class IosFileStorage(
      * @return The progress state, or null if no progress file exists or is corrupt
      */
     fun loadChainProgress(chainId: String): ChainProgress? {
-        val progressFile = chainsDirURL.safeAppend("${chainId}_progress.json")
+        val progressFile = chainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}_progress.json")
 
         return coordinated(progressFile, write = false) { safeUrl ->
             val json = readStringFromFile(safeUrl) ?: return@coordinated null
@@ -1251,7 +1251,7 @@ public class IosFileStorage(
         progressMutex.withLock {
             progressBuffer.remove(chainId)
         }
-        val progressFile = chainsDirURL.safeAppend("${chainId}_progress.json")
+        val progressFile = chainsDirURL.safeAppend("${chainId.encodeAsPathComponent()}_progress.json")
         deleteFile(progressFile)
         Logger.d(LogTags.CHAIN, "Deleted chain progress $chainId (buffer + disk)")
     }
@@ -1263,7 +1263,7 @@ public class IosFileStorage(
      */
     fun saveTaskMetadata(id: String, metadata: Map<String, String>, periodic: Boolean) {
         val dir = if (periodic) periodicDirURL else tasksDirURL
-        val metaFile = dir.safeAppend("$id.json")
+        val metaFile = dir.safeAppend("${id.encodeAsPathComponent()}.json")
         val json = Json.encodeToString(metadata)
 
         coordinated(metaFile, write = true) { safeUrl ->
@@ -1278,7 +1278,7 @@ public class IosFileStorage(
      */
     fun loadTaskMetadata(id: String, periodic: Boolean): Map<String, String>? {
         val dir = if (periodic) periodicDirURL else tasksDirURL
-        val metaFile = dir.safeAppend("$id.json")
+        val metaFile = dir.safeAppend("${id.encodeAsPathComponent()}.json")
 
         return coordinated(metaFile, write = false) { safeUrl ->
             val json = readStringFromFile(safeUrl) ?: return@coordinated null
@@ -1337,7 +1337,7 @@ public class IosFileStorage(
      */
     fun deleteTaskMetadata(id: String, periodic: Boolean) {
         val dir = if (periodic) periodicDirURL else tasksDirURL
-        val metaFile = dir.safeAppend("$id.json")
+        val metaFile = dir.safeAppend("${id.encodeAsPathComponent()}.json")
         deleteFile(metaFile)
         Logger.d(LogTags.SCHEDULER, "Deleted ${if (periodic) "periodic" else "task"} metadata for $id")
     }
@@ -1629,6 +1629,39 @@ class InsufficientDiskSpaceException(
 private fun NSURL.safeAppend(component: String): NSURL =
     URLByAppendingPathComponent(component)
         ?: throw IllegalStateException("Failed to construct URL: base='$path' component='$component'")
+
+/**
+ * Encodes a caller-supplied task/chain id for safe use as a single filesystem path
+ * component (e.g. `"$id.json"` in [saveTaskMetadata], `"${chainId}_progress.json"` in the
+ * chain-progress paths).
+ *
+ * Task and chain ids come straight from the public API (`scheduler.enqueue(id, ...)`,
+ * `TaskChain.withId(...)`) and are interpolated directly into filenames throughout this
+ * class. Unescaped, an id containing `/` lets a caller construct additional path
+ * segments, and an id that is exactly `.` or `..` is a reserved filesystem name with
+ * special meaning — either could produce a path outside the intended storage directory
+ * (`safeAppend` only guards against `URLByAppendingPathComponent` returning null; it has
+ * no traversal awareness).
+ *
+ * Deliberately narrow — only `/`, a bare `.`/`..`, and (to keep the mapping injective,
+ * see below) literal `%` are percent-encoded. Every other character, including letters,
+ * digits, `-`, `_`, dots within a longer string, and Unicode, passes through unchanged.
+ * Broadening this (e.g. escaping all non-ASCII) would change the on-disk filename for
+ * ids that are already safe today, silently breaking `loadTaskMetadata`/
+ * `loadChainDefinition` for tasks an app scheduled before upgrading past this fix. Only
+ * genuinely hazardous ids change filename — and a genuinely hazardous id was never going
+ * to resolve correctly before this fix either.
+ *
+ * `%` is escaped first, before `/`, so the mapping stays injective: without this, an id
+ * containing the literal text `"%2F"` would be indistinguishable on disk from an id
+ * containing a real `/` — two different ids silently sharing one file.
+ */
+internal fun String.encodeAsPathComponent(): String {
+    if (this == ".") return "%2E"
+    if (this == "..") return "%2E%2E"
+    if ('%' !in this && '/' !in this) return this
+    return replace("%", "%25").replace("/", "%2F")
+}
 
 /** Converts a UTF-8 string to NSData using byte array encoding (not char count). */
 @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V331PathTraversalTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V331PathTraversalTest.kt
@@ -1,0 +1,178 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package dev.brewkits.kmpworkmanager
+
+import dev.brewkits.kmpworkmanager.background.data.IosFileStorage
+import dev.brewkits.kmpworkmanager.background.data.encodeAsPathComponent
+import dev.brewkits.kmpworkmanager.background.domain.TaskRequest
+import kotlinx.coroutines.test.runTest
+import platform.Foundation.NSDate
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.timeIntervalSince1970
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression net for a review finding: task/chain ids are caller-supplied
+ * (`scheduler.enqueue(id, ...)`, `TaskChain.withId(...)`) and were interpolated directly
+ * into filenames across 13 call sites in `IosFileStorage` with no sanitization —
+ * `dir.safeAppend("$id.json")`. `safeAppend` only guards against
+ * `URLByAppendingPathComponent` returning null (NPE-safety); it has no traversal
+ * awareness. Fixed via `String.encodeAsPathComponent()`.
+ *
+ * Two layers of coverage:
+ * - Pure unit tests of `encodeAsPathComponent()` — fast, deterministic, and the right
+ *   place to pin the injectivity/backward-compatibility properties precisely.
+ * - An integration test through the real `IosFileStorage` API, because the property
+ *   that actually matters in production — whether a hostile id can make
+ *   `URLByAppendingPathComponent`/`NSFileManager` write outside the intended directory —
+ *   depends on Foundation's own path-resolution behavior, not just this function's
+ *   output string.
+ */
+class V331PathTraversalTest {
+
+    // ── Pure unit tests of the encoder ──────────────────────────────────────────
+
+    @Test
+    fun `ordinary ids pass through unchanged`() {
+        // Backward compatibility is the whole point: an app already running with
+        // task ids like these must resolve to the exact same on-disk filename after
+        // upgrading, or metadata for already-scheduled tasks silently "disappears".
+        listOf(
+            "nightly-sync",
+            "upload_1",
+            "com.example.SyncTask",
+            "task.name.v2",
+            "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+            "任务同步"
+        ).forEach { id ->
+            assertEquals(id, id.encodeAsPathComponent(), "safe id must round-trip unchanged: '$id'")
+        }
+    }
+
+    @Test
+    fun `a slash is percent-encoded`() {
+        assertEquals("a%2Fb", "a/b".encodeAsPathComponent())
+        assertEquals("%2Fetc%2Fpasswd", "/etc/passwd".encodeAsPathComponent())
+    }
+
+    @Test
+    fun `traversal-shaped ids are percent-encoded not left able to add path segments`() {
+        val encoded = "../../../etc/passwd".encodeAsPathComponent()
+        assertTrue('/' !in encoded, "encoded output must never contain a literal '/': $encoded")
+    }
+
+    @Test
+    fun `bare dot and double-dot are escaped as the reserved filesystem names they are`() {
+        assertEquals("%2E", ".".encodeAsPathComponent())
+        assertEquals("%2E%2E", "..".encodeAsPathComponent())
+        // A dot WITHIN a longer id is not a reserved name and must not be touched —
+        // this is what keeps "com.example.SyncTask" round-tripping above.
+        assertEquals("a.b", "a.b".encodeAsPathComponent())
+    }
+
+    @Test
+    fun `encoding is injective a literal percent-slash cannot collide with a real slash`() {
+        // Without escaping '%' first, the id "a%2Fb" (someone's literal string) and the id
+        // "a/b" (an actual slash) would both encode to "a%2Fb" -- two different ids
+        // silently sharing one file. Escaping '%' before '/' rules this out.
+        val real = "a/b".encodeAsPathComponent()
+        val literal = "a%2Fb".encodeAsPathComponent()
+        assertNotEquals(real, literal, "a real '/' and the literal text '%2F' must not collide")
+    }
+
+    @Test
+    fun `distinct hostile ids encode to distinct filenames`() {
+        val ids = listOf(
+            "../../../etc/passwd", "..", ".", "a/../../b",
+            "/etc/passwd", "a/b", "b/a", "%2Fetc%2Fpasswd"
+        )
+        val encoded = ids.map { it.encodeAsPathComponent() }
+        assertEquals(ids.size, encoded.toSet().size, "no two distinct hostile ids may collide: $encoded")
+    }
+
+    // ── Integration: the real IosFileStorage API ────────────────────────────────
+
+    private lateinit var storage: IosFileStorage
+    private lateinit var testDirectory: NSURL
+
+    @BeforeTest
+    fun setup() {
+        val name = "V331PathTraversalTest-${(NSDate().timeIntervalSince1970 * 1000).toLong()}-${platform.posix.rand()}"
+        testDirectory = NSURL.fileURLWithPath("${NSTemporaryDirectory()}$name")
+        NSFileManager.defaultManager.createDirectoryAtURL(testDirectory, withIntermediateDirectories = true, attributes = null, error = null)
+        storage = IosFileStorage(baseDirectory = testDirectory)
+    }
+
+    @AfterTest
+    fun tearDown() = runTest {
+        storage.close()
+        NSFileManager.defaultManager.removeItemAtURL(testDirectory, error = null)
+    }
+
+    @Test
+    fun `task metadata round-trips for a hostile id without escaping the storage directory`() = runTest {
+        val hostileId = "../../../etc/passwd"
+        val metadata = mapOf("workerClassName" to "SyncWorker", "inputJson" to "null")
+
+        storage.saveTaskMetadata(hostileId, metadata, periodic = false)
+
+        val tasksDir = testDirectory.URLByAppendingPathComponent("metadata")!!.URLByAppendingPathComponent("tasks")!!
+        val entries = NSFileManager.defaultManager
+            .contentsOfDirectoryAtPath(tasksDir.path!!, error = null)
+            ?: emptyList<Any?>()
+        assertEquals(1, entries.size, "exactly one file must be written, inside metadata/tasks/, got: $entries")
+
+        val loaded = storage.loadTaskMetadata(hostileId, periodic = false)
+        assertEquals(metadata, loaded, "the hostile id must still round-trip correctly through the public API")
+    }
+
+    @Test
+    fun `two hostile ids that differ only by path shape do not clobber each other`() = runTest {
+        val idA = "a/b"
+        val idB = "b/a"
+
+        storage.saveTaskMetadata(idA, mapOf("workerClassName" to "WorkerA"), periodic = false)
+        storage.saveTaskMetadata(idB, mapOf("workerClassName" to "WorkerB"), periodic = false)
+
+        assertEquals(mapOf("workerClassName" to "WorkerA"), storage.loadTaskMetadata(idA, periodic = false))
+        assertEquals(mapOf("workerClassName" to "WorkerB"), storage.loadTaskMetadata(idB, periodic = false))
+    }
+
+    @Test
+    fun `chain definition survives a hostile chainId`() = runTest {
+        val hostileChainId = "../../evil-chain"
+        storage.saveChainDefinition(hostileChainId, listOf(listOf(TaskRequest("SyncWorker"))))
+
+        val chainsDir = testDirectory.URLByAppendingPathComponent("chains")!!
+        val entries = NSFileManager.defaultManager
+            .contentsOfDirectoryAtPath(chainsDir.path!!, error = null)
+            ?: emptyList<Any?>()
+        assertEquals(1, entries.size, "exactly one chain definition file must exist, inside chains/, got: $entries")
+
+        val loaded = storage.loadChainDefinition(hostileChainId)
+        assertEquals(1, loaded?.size, "the hostile chainId must still round-trip correctly")
+    }
+
+    @Test
+    fun `ordinary ids still produce the expected literal filename on disk`() {
+        // Backward-compat, proven on disk rather than just at the string level: an
+        // ordinary id must land at exactly the filename it always did.
+        runTest { storage.saveTaskMetadata("nightly-sync", mapOf("k" to "v"), periodic = false) }
+
+        val expectedFile = testDirectory
+            .URLByAppendingPathComponent("metadata")!!
+            .URLByAppendingPathComponent("tasks")!!
+            .URLByAppendingPathComponent("nightly-sync.json")!!
+        assertTrue(
+            NSFileManager.defaultManager.fileExistsAtPath(expectedFile.path!!),
+            "an ordinary id must still produce the literal 'nightly-sync.json' filename"
+        )
+    }
+}


### PR DESCRIPTION
Two findings from a senior mobile QA/review pass, unrelated to each other and to #72 — separate PR intentionally.

## 1. KSP: silent overwrite on colliding `@Worker` name/alias

`generateAndroidFactory`/`generateIosFactory` emit one `put(key) { ... }` per worker name + alias into the generated `providers` map. Two different `@Worker` classes claiming the same key — explicit name collision, same default `simpleName` in different packages, or an alias colliding with another worker's name/alias — silently overwrote one another. No compile error, no KSP warning. One worker becomes permanently unreachable at runtime.

Same bug class this project has been burned by before (`PendingIntentCodes` — `String.hashCode()` collisions splitting alarms across reboots).

**Fix:** `validateNoDuplicateKeys()` runs before generation per platform, `logger.error()`s (fails the build) listing every colliding key and all classes claiming it.

**Test note:** `WorkerProcessorTest` (21 tests) is entirely `@Ignore`d — kctfork 0.6.0 never invokes the processor for in-memory `SourceFile`s (documented in its own class KDoc), so none of those tests actually run in CI today. Rather than add a 22nd test to a harness that silently never executes, `WorkerProcessorDuplicateKeyTest` calls `validateNoDuplicateKeys` directly with synthetic `WorkerInfo` + a fake `KSPLogger` — the real production method, actually running. 6/6 pass.

## 2. iOS: caller-supplied ids used unsanitized as filenames

Task/chain ids come straight from the public API (`scheduler.enqueue(id, ...)`, `TaskChain.withId(...)`) and were interpolated directly into filenames at 13 call sites in `IosFileStorage` — `dir.safeAppend("$id.json")` and its chain/progress/marker variants. `safeAppend` only guards `URLByAppendingPathComponent` returning null (NPE-safety), not traversal.

**Fix:** `String.encodeAsPathComponent()`, applied at all 13 sites. Deliberately narrow — only `/`, a bare `.`/`..`, and (for injectivity) a literal `%` are percent-encoded. Everything else, including dots within a longer id and Unicode, passes through unchanged. This is the load-bearing design choice: broadening it would silently change the on-disk filename for already-safe ids, breaking `loadTaskMetadata`/`loadChainDefinition` for tasks scheduled before an app upgrades past this fix.

**Test note:** `V331PathTraversalTest` covers both the pure encoder (backward-compat, injectivity) and integration through the real `IosFileStorage` API with hostile ids — verified against actual `NSFileManager`/`NSURL` behavior on the simulator rather than assumed. 10/10 pass.

## Verification

- iOS: 887 tests, 0 failures
- Android: 503 tests, 0 failures
- KSP: 29 tests, 0 failures
- `composeApp` (Android + iOS) still compiles