### PR TITLE
docs: changelog + roadmap entries for 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to KMP WorkManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.1] - 2026-08-08
+## [3.3.1] - 2026-08-09
+
+A senior mobile QA/QC review pass across the whole library surfaced five further findings
+on top of issue #71 — all fixed here. None are regressions from 3.3.0 shipping; all were
+either narrow-trigger latent gaps or, in one case, code written for this very release that
+hadn't reached Maven Central yet.
 
 ### Fixed
 
@@ -22,6 +27,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mirroring `ChainExecutor` and Android's `BaseKmpWorker`. `executeTask` gained an optional
   `taskId` parameter (all three internal call sites now pass it) used as
   `ExecutionRecord.chainId`, the same convention `BaseKmpWorker` uses on Android.
+- **iOS: `SingleTaskExecutor` used a wall-clock diff for `ExecutionRecord.durationMs`.**
+  The exact class of bug `ChainExecutor.executeStep` already guards against for the
+  identical reason (see 3.3.0's `withTimeoutOrNull` entry below): an NTP sync or manual
+  clock change mid-task (up to 120s for `BGProcessingTask`) could silently corrupt the
+  persisted duration. This was in code written for the `executeTask`/`taskId` fix above,
+  caught during the same review before it ever reached a release. Now uses
+  `TimeSource.Monotonic` for the duration, wall-clock only for the `startedAtMs`/`endedAtMs`
+  timestamp fields — mirroring `ChainExecutor`'s existing split exactly.
+- **KSP: two `@Worker` classes claiming the same name or alias silently overwrote one
+  another** in the generated `providers` map — no compile error, no KSP warning. One
+  worker became permanently unreachable at runtime. `WorkerProcessor` now fails the build
+  (`logger.error()`) listing every colliding key and the classes claiming it. Covered by
+  `WorkerProcessorDuplicateKeyTest`, which calls the validation directly rather than
+  through `WorkerProcessorTest`'s compile-testing harness — that entire 21-test class is
+  `@Ignore`d (kctfork 0.6.0 never invokes the processor for in-memory sources), so none of
+  those tests actually run in CI today.
+- **iOS: caller-supplied task/chain ids were used unsanitized as filenames** at 13 call
+  sites in `IosFileStorage` (`saveTaskMetadata`, chain definition/progress/deleted-marker
+  files) — `dir.safeAppend("$id.json")`, where `safeAppend` only guards against
+  `URLByAppendingPathComponent` returning null, not path traversal. Ids containing `/` or
+  equal to `.`/`..` are now percent-encoded via `String.encodeAsPathComponent()`.
+  Deliberately narrow: only `/`, a bare `.`/`..`, and (for injectivity) a literal `%` are
+  escaped, so ordinary ids (`"nightly-sync"`, `"com.example.sync"`, UUIDs) produce the
+  exact same on-disk filename as before — tasks an app scheduled before upgrading past
+  this fix keep resolving correctly.
+- **`kmpworkmanager-http`: the HTTP clients' `User-Agent` header hardcoded
+  `"KmpWorkManager/2.3.4"`**, un-synced with the real published version across every
+  release since (13 releases stale at 3.3.0). `:kmpworker-http` now generates a
+  `LIBRARY_VERSION` constant from `VERSION_NAME` on every build, so the header can't drift
+  from the actual release again.
+- **`kmpworkmanager-http`: the SSRF-aware manual redirect-following interceptor was
+  duplicated verbatim** between `HttpClientProvider.android.kt` and
+  `HttpClientProvider.ios.kt` (~25 identical lines re-validating each `Location` header via
+  `SecurityValidator`, capping at 10 hops, stripping `Authorization`/`Cookie` on
+  cross-origin hops). The logic itself was correct; being security-critical, two copies
+  risked silently drifting apart on a future change landing in only one file. Extracted to
+  a single `HttpClient.installSecureRedirectFollowing()` in commonMain.
 
 ## [3.3.0] - 2026-08-08
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -401,6 +401,46 @@ the fix consumers are asking for further away for no benefit.
 
 ---
 
+## v3.3.1 — senior mobile QA/QC review pass — ✅ shipped
+
+**Theme:** a full-library review (correctness, architecture, test-coverage gaps,
+iOS/Android lifecycle & threading pitfalls) turned up six findings on top of
+[issue #71](https://github.com/brewkits/kmpworkmanager/issues/71) (iOS single tasks not
+persisting event/history, filed during 3.3.0 verification). None are regressions —
+either narrow-trigger latent gaps or, in one case, code written for 3.3.0 that hadn't
+reached Maven Central yet when the bug was found.
+
+- ✅ **iOS: `SingleTaskExecutor` didn't persist events/history for non-chained tasks**
+  (#71). Routed through `TaskEventManager.emit()` + `ExecutionHistoryStore.save()`,
+  mirroring `ChainExecutor`/`BaseKmpWorker`. `V331SingleTaskPersistenceTest`.
+- ✅ **iOS: `SingleTaskExecutor` used wall-clock for `ExecutionRecord.durationMs`** — the
+  same NTP-drift risk `ChainExecutor` already guards against, found in the fix above
+  before it shipped. Switched to `TimeSource.Monotonic`, matching `ChainExecutor`'s split.
+- ✅ **KSP: colliding `@Worker` name/alias silently overwrote one worker in the generated
+  factory** — no compile error, no warning. `WorkerProcessor` now `logger.error()`s.
+  `WorkerProcessorDuplicateKeyTest` calls the validation directly, since
+  `WorkerProcessorTest`'s entire 21-test compile-testing harness is `@Ignore`d
+  (kctfork 0.6.0 never invokes the processor for in-memory sources — none of those tests
+  run in CI today).
+- ✅ **iOS: task/chain ids used unsanitized as filenames** at 13 `IosFileStorage` call
+  sites — `safeAppend` guards only NPE, not traversal. Fixed via
+  `String.encodeAsPathComponent()`, deliberately narrow (only `/`, bare `.`/`..`, and `%`
+  for injectivity) so ordinary ids keep their exact pre-fix on-disk filename.
+  `V331PathTraversalTest` covers both the pure encoder and the real `IosFileStorage` API.
+- ✅ **`kmpworkmanager-http`: `User-Agent` hardcoded `"KmpWorkManager/2.3.4"`**, 13
+  releases stale. `:kmpworker-http` now generates `LIBRARY_VERSION` from `VERSION_NAME`
+  on every build.
+- ✅ **`kmpworkmanager-http`: SSRF-aware redirect-following interceptor duplicated
+  verbatim** between the Android and iOS `HttpClientProvider`s. Extracted to
+  `HttpClient.installSecureRedirectFollowing()` in commonMain — one copy of
+  security-critical logic instead of two that could silently drift apart.
+
+**Verification:** 887 iOS + 503 Android + 29 KSP + 38×2 `kmpworker-http` tests, 0
+failures across all of #71/finding-1/finding-2/finding-3/findings-4-5's PRs
+(#72, #73, #74).
+
+---
+
 ## v3.0 — long-term (P3)
 
 **Theme:** the library's foundation can be sturdier. These are non-trivial


### PR DESCRIPTION
Fills in the 3.3.1 CHANGELOG section (only issue #71 was documented) with the other five findings from the senior QA/QC review pass, and adds a matching v3.3.1 ROADMAP milestone. Docs only — no code changes. Follows #72, #73, #74.