### PR TITLE
fix(ios): derive master dispatcher requiresNetworkConnectivity from pending queue

### DIFF
--- a/docs/IOS_BGTASK_LIMITS.md
+++ b/docs/IOS_BGTASK_LIMITS.md
@@ -324,6 +324,45 @@ fired by now. If the user never opens the app, **the task waits indefinitely**.
 
 ---
 
+## 6. Dynamic-task master dispatcher is always a `BGProcessingTask`, never a `BGAppRefreshTask`
+
+### What's actually happening
+
+Dynamic task IDs (not declared in `Info.plist`) are queued internally and
+woken via the single static `kmp_master_dispatcher_task` identifier. That
+dispatcher is **always** submitted as a `BGProcessingTaskRequest` —
+`requiresNetworkConnectivity` is now derived from the pending queue (`true`
+only when *every* pending task requires network; see the fix below), but the
+request *type* itself never becomes the cheaper, more favorably-scheduled
+`BGAppRefreshTaskRequest`, even when every pending task is light. That's
+deliberate: `BGAppRefreshTask`'s hard ~30s ceiling (no extension API) leaves
+no safe margin for the batch executor's per-task timeout (25s) plus wake and
+completion overhead — see
+[docs/ios-dynamic-task-scheduling.md § 5](ios-dynamic-task-scheduling.md#why-not-bgapprefreshtaskrequest-when-the-queue-is-all-light)
+for the full reasoning.
+
+### Library guarantees
+
+- ✅ A task scheduled with a **static ID** declared in `Info.plist` correctly
+  becomes a `BGAppRefreshTaskRequest` when `Constraints.isHeavyTask = false`.
+- ✅ `requiresNetworkConnectivity` on the dynamic-task master dispatcher is
+  `true` when every pending dynamic task requires network, `false` otherwise
+  — so an all-network-dependent queue no longer wakes opportunistically
+  offline just to fail every task and re-queue them.
+- ❌ Dynamic task IDs never get a `BGAppRefreshTaskRequest`, even when every
+  pending task is light — the master dispatcher's request *type* is fixed.
+
+### Workaround
+
+Declare a dedicated static ID for lightweight, network-bound work instead of
+relying on the dynamic-task path — that's the only way to get an actual
+`BGAppRefreshTaskRequest` today. See
+[docs/ios-dynamic-task-scheduling.md § 5](ios-dynamic-task-scheduling.md#5-known-trade-off-master-dispatcher-ignores-per-task-constraints)
+for the full explanation and the tracked follow-up
+([#79](https://github.com/brewkits/kmpworkmanager/issues/79)).
+
+---
+
 ## Summary table
 
 | Limit | Hard ceiling | Library can mitigate? | Workaround |
@@ -333,6 +372,7 @@ fired by now. If the user never opens the app, **the task waits indefinitely**.
 | Headless DI cold-start | ~10 s before budget starts ticking | No | Lazy-init non-BGTask deps; measure cold-start on real devices |
 | No ZIP codec | K/N stdlib gap | Yes (fail-fast default) | Use Swift host for compression, or wait for v2.6 zlib cinterop |
 | Exact alarms need user action | iOS has no "wake at time T and run code" primitive | Partial (catch-up on app open) | Use `UNUserNotification` for user-visible alarms; server-side scheduler for SLA-critical timing |
+| Master dispatcher never becomes `BGAppRefreshTask` | Always `BGProcessingTaskRequest` — 25s per-task timeout leaves no margin under App Refresh's 30s ceiling | No (not safe with current batch executor; network flag alone is fixed) | Use a dedicated static `Info.plist` ID for light tasks |
 
 ---
 

--- a/docs/ios-dynamic-task-scheduling.md
+++ b/docs/ios-dynamic-task-scheduling.md
@@ -61,3 +61,26 @@ As of version **2.4.3**, KMP WorkManager has implemented **Option 2** (the Libra
 
 This architecture delivers a seamless, unified Developer Experience (DX) across Android and iOS, perfectly aligning with the "Write once, run anywhere" philosophy of Kotlin Multiplatform.
 
+---
+
+## 5. Known Trade-off: Master Dispatcher Ignores Per-Task Constraints
+
+The master dispatcher always submits `kmp_master_dispatcher_task` as a **`BGProcessingTaskRequest`**. As of the fix below, `requiresNetworkConnectivity` is derived from the pending queue; the request *type* itself is always `BGProcessingTaskRequest`, never `BGAppRefreshTaskRequest` — see "Why not `BGAppRefreshTaskRequest`?" below for why that's deliberate, not an oversight.
+
+* **Why unconstrained by default:** a dynamic-task queue is typically mixed (some tasks need network, some don't; some are light, some are heavy). Submitting an unconstrained `BGProcessingTaskRequest` lets non-network tasks run opportunistically even while offline — each worker still checks its own `Constraints.requiresNetwork` at execution time and fails/retries if unmet. Constraining the dispatcher itself would block the *whole* batch on the strictest pending task.
+* **What's fixed:** `NativeTaskScheduler.submitTaskRequest` and `DynamicTaskDispatcher.rescheduleMasterDispatcher` now read `IosFileStorage.getDynamicQueueConstraintSummary()` and set `requiresNetworkConnectivity = true` only when **every** pending dynamic task requires network — so a queue that's entirely network-dependent no longer wakes opportunistically while offline just to fail every task and re-queue them.
+* **This only affects dynamic task IDs.** A task scheduled with a **static ID declared in `Info.plist`** goes through `createBackgroundTaskRequest()` directly and correctly becomes a `BGAppRefreshTaskRequest` when `Constraints.isHeavyTask = false`.
+
+### Why not `BGAppRefreshTaskRequest` when the queue is all-light?
+
+This was the original ask in [discussion #78](https://github.com/brewkits/kmpworkmanager/discussions/78) — use the cheaper, better-scheduled `BGAppRefreshTaskRequest` when every pending task is light. It turns out **not to be safe** with the current batch executor, so it's deliberately not implemented:
+
+* `BGAppRefreshTask` has a hard ceiling of **~30 seconds with no extension API** (see [IOS_BGTASK_LIMITS.md § 1](./IOS_BGTASK_LIMITS.md)).
+* `DynamicTaskDispatcher.executePendingTasks` dequeues and runs tasks in a loop; a single dequeued task may run up to `SingleTaskExecutor.DEFAULT_TIMEOUT_MS` (**25 seconds**) before its own per-task timeout fires.
+* 25s of worker execution plus BGTask wake latency and completion/cleanup overhead leaves no safe margin under a 30s hard ceiling — not even for a *single* queued task, let alone a batch. Unlike a static light task (one task, one `BGAppRefreshTask` window, by construction), the master dispatcher is a **batch** processor sized for `BGProcessingTask`'s multi-minute budget; "every pending task is light" does not mean "the batch fits in 30 seconds."
+* Making this safe would require the dispatcher to know it's running under an App Refresh budget and cap itself to (at most) one task with a much smaller per-task timeout — plus verification on a physical device, since the Simulator doesn't model real `BGTaskScheduler` timing (see the iOS Simulator Fallback warning in `NativeTaskScheduler.kt`).
+
+Tracked as follow-up scope in [brewkits/kmpworkmanager#79](https://github.com/brewkits/kmpworkmanager/issues/79) if it's worth pursuing later.
+
+**Workaround today:** for lightweight, network-bound, latency-sensitive work, declare a dedicated static ID in `BGTaskSchedulerPermittedIdentifiers` instead of relying on the dynamic-task/master-dispatcher path — that's still the only way to get an actual `BGAppRefreshTaskRequest` for iOS background work in this library.
+

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
@@ -274,17 +274,29 @@ public class DynamicTaskDispatcher(
 
     private fun currentTimeMs(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()
 
-    private fun rescheduleMasterDispatcher() {
+    private suspend fun rescheduleMasterDispatcher() {
         if (NSBundle.mainBundle.bundleIdentifier == null) return
+
+        // Derive requiresNetworkConnectivity from what's actually still pending, instead of
+        // always requesting unconstrained. See docs/ios-dynamic-task-scheduling.md § 5.
+        //
+        // The dispatcher stays a BGProcessingTaskRequest here (never BGAppRefreshTaskRequest)
+        // even when every pending task is light — see the NOTE in
+        // NativeTaskScheduler.submitTaskRequest's dynamic-task branch for why that's not safe
+        // yet with the current batch executor's per-task timeout budget.
+        val summary = fileStorage.getDynamicQueueConstraintSummary()
+        val requiresNetwork = summary.allRequireNetwork
 
         memScoped {
             val errorPtr = alloc<ObjCObjectVar<NSError?>>()
-            val request = BGProcessingTaskRequest("kmp_master_dispatcher_task")
-            request.earliestBeginDate = NSDate()
-            // Individual task network constraints are checked by each worker.
-            // false here allows non-network tasks to run opportunistically even without
-            // connectivity; workers that need network return Failure and remain in the queue.
-            request.requiresNetworkConnectivity = false
+            val request = BGProcessingTaskRequest("kmp_master_dispatcher_task").apply {
+                earliestBeginDate = NSDate()
+                // Individual task network constraints are checked by each worker.
+                // Only require network here when EVERY pending task needs it — otherwise
+                // false lets non-network tasks run opportunistically even without
+                // connectivity; workers that need network return Failure and remain queued.
+                requiresNetworkConnectivity = requiresNetwork
+            }
 
             val ok = BGTaskScheduler.sharedScheduler.submitTaskRequest(request, errorPtr.ptr)
             if (!ok) {

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -43,6 +43,22 @@ internal data class ChainTransaction(
 )
 
 /**
+ * Aggregate light/network profile of the tasks currently pending in the dynamic-task queue.
+ * See [IosFileStorage.getDynamicQueueConstraintSummary].
+ */
+internal data class DynamicQueueConstraintSummary(
+    val pendingCount: Int,
+    val heavyCount: Int,
+    val networkRequiredCount: Int
+) {
+    /** True when every pending task is light — safe to schedule as `BGAppRefreshTask`. */
+    val allLight: Boolean get() = pendingCount > 0 && heavyCount == 0
+
+    /** True when every pending task requires network connectivity. */
+    val allRequireNetwork: Boolean get() = pendingCount > 0 && networkRequiredCount == pendingCount
+}
+
+/**
  * Configuration for [IosFileStorage].
  *
  * @param diskSpaceBufferBytes Minimum free space required before any write (safety margin).
@@ -513,6 +529,36 @@ public class IosFileStorage(
      * which is acceptable since getQueueSize() is called infrequently (once per BGTask).
      */
     suspend fun getQueueSize(): Int = queue.getSize()
+
+    /**
+     * Aggregate light/network profile of every task currently sitting in the dynamic-task
+     * queue. Lets the master dispatcher be scheduled with constraints that actually match
+     * what's pending, instead of always requesting an unconstrained `BGProcessingTask`.
+     * See docs/ios-dynamic-task-scheduling.md § 5.
+     *
+     * Always reads from disk (like [getQueueSize]) — the same multi-instance staleness
+     * concern applies, and this is called once per master-dispatcher schedule decision,
+     * not per task, so the extra I/O is acceptable.
+     *
+     * **Performance**: O(N) on queue size (bounded by [MAX_QUEUE_SIZE]) — one metadata
+     * read per pending task.
+     */
+    internal suspend fun getDynamicQueueConstraintSummary(): DynamicQueueConstraintSummary {
+        val ids = tasksQueue.getAllItems()
+        var heavyCount = 0
+        var networkCount = 0
+        for (id in ids) {
+            // A dynamic task ID is either one-time or periodic metadata — never both.
+            val meta = loadTaskMetadata(id, periodic = false) ?: loadTaskMetadata(id, periodic = true)
+            if (meta?.get("isHeavyTask") == "true") heavyCount++
+            if (meta?.get("requiresNetwork") == "true") networkCount++
+        }
+        return DynamicQueueConstraintSummary(
+            pendingCount = ids.size,
+            heavyCount = heavyCount,
+            networkRequiredCount = networkCount
+        )
+    }
 
     /**
      * Sort the execution queue by task priority (highest first).

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -607,18 +607,38 @@ public class NativeTaskScheduler(
     }
 
     /**
-     * Returns the earliestBeginDate of the currently-pending Master Dispatcher request,
-     * or null if no such request is pending (or in test mode).
-     * Used to avoid pushing back the dispatcher when a later-dated dynamic task is enqueued.
+     * Snapshot of the currently-pending Master Dispatcher request, or null if none is
+     * pending (or in test mode). The dispatcher is always a `BGProcessingTaskRequest`
+     * (see [submitTaskRequest]'s dynamic-task branch for why it never becomes a
+     * `BGAppRefreshTaskRequest`); [requiresNetwork] lets that branch decide whether the
+     * aggregate queue profile now needs a different `requiresNetworkConnectivity` value,
+     * not just a date change.
      */
-    private suspend fun getPendingMasterDispatcherDate(): NSDate? {
+    private data class PendingMasterDispatcherInfo(
+        val earliestBeginDate: NSDate?,
+        val requiresNetwork: Boolean
+    )
+
+    /**
+     * Returns a snapshot of the currently-pending Master Dispatcher request (date +
+     * requiresNetworkConnectivity), or null if none is pending.
+     * Used to avoid pushing back the dispatcher when a later-dated dynamic task is enqueued,
+     * and to detect when the aggregate queue profile now requires a different network flag.
+     */
+    private suspend fun getPendingMasterDispatcherInfo(): PendingMasterDispatcherInfo? {
         if (NSBundle.mainBundle.bundleIdentifier == null) return null
         return suspendCancellableCoroutine { continuation ->
             BGTaskScheduler.sharedScheduler.getPendingTaskRequestsWithCompletionHandler { requests ->
                 if (continuation.isActive) {
-                    val master = requests?.filterIsInstance<BGTaskRequest>()
+                    val master = requests?.filterIsInstance<BGProcessingTaskRequest>()
                         ?.find { it.identifier == MASTER_DISPATCHER_IDENTIFIER }
-                    continuation.resume(master?.earliestBeginDate)
+                    val info = master?.let {
+                        PendingMasterDispatcherInfo(
+                            earliestBeginDate = it.earliestBeginDate,
+                            requiresNetwork = it.requiresNetworkConnectivity
+                        )
+                    }
+                    continuation.resume(info)
                 }
             }
             continuation.invokeOnCancellation { }
@@ -666,21 +686,53 @@ public class NativeTaskScheduler(
 
                 val proposedDate = request.earliestBeginDate
 
-                // Only reschedule Master Dispatcher if the proposed date is earlier than the
-                // currently-pending one. Submitting a later date silently replaces an earlier
-                // pending request, delaying tasks already waiting in the queue.
-                val existingMasterDate = getPendingMasterDispatcherDate()
-                if (existingMasterDate != null && proposedDate != null &&
-                    proposedDate.timeIntervalSinceDate(existingMasterDate) >= 0) {
+                // Derive the Master Dispatcher's requiresNetworkConnectivity from what's
+                // actually pending now (including the task just enqueued above), instead of
+                // always submitting unconstrained. See docs/ios-dynamic-task-scheduling.md § 5.
+                //
+                // NOTE: the dispatcher always stays a BGProcessingTaskRequest here — it does
+                // NOT switch to BGAppRefreshTaskRequest for all-light queues. That looked like
+                // the obvious next step but isn't safe with the current batch executor:
+                // BGAppRefreshTask has a hard ~30s ceiling with no extension API
+                // (docs/IOS_BGTASK_LIMITS.md § 1), while a single dequeued task may run up to
+                // SingleTaskExecutor.DEFAULT_TIMEOUT_MS (25s) — there's no safe margin left for
+                // wake latency + completion overhead, let alone a second task in the batch.
+                // Tracked as follow-up scope in issue #79.
+                val summary = fileStorage.getDynamicQueueConstraintSummary()
+                val desiredRequiresNetwork = summary.allRequireNetwork
+
+                val existing = getPendingMasterDispatcherInfo()
+                val existingDate = existing?.earliestBeginDate
+                val proposedIsNotEarlier = existingDate != null && proposedDate != null &&
+                    proposedDate.timeIntervalSinceDate(existingDate) >= 0
+                val networkFlagUnchanged = existing != null && existing.requiresNetwork == desiredRequiresNetwork
+
+                // Only reschedule the Master Dispatcher if the proposed date is earlier than the
+                // currently-pending one, OR the aggregate queue profile now needs a different
+                // requiresNetworkConnectivity value. Submitting a later date (with no flag
+                // change) would silently replace an earlier pending request, delaying tasks
+                // already waiting.
+                if (existing != null && proposedIsNotEarlier && networkFlagUnchanged) {
                     Logger.d(LogTags.SCHEDULER,
-                        "Master Dispatcher already scheduled earlier — keeping existing schedule for '$id'")
+                        "Master Dispatcher already scheduled earlier with matching constraints — keeping existing schedule for '$id'")
                     return ScheduleResult.ACCEPTED
                 }
 
+                // When resubmitting, never regress an earlier date already pending — the same
+                // identifier replaces the old request on submit regardless of date, so pick the
+                // earlier of the two if both exist.
+                val earliestBeginDate = when {
+                    existingDate != null && proposedDate != null ->
+                        if (existingDate.timeIntervalSinceDate(proposedDate) < 0) existingDate else proposedDate
+                    existingDate != null -> existingDate
+                    else -> proposedDate
+                }
+
+                Logger.d(LogTags.SCHEDULER, "Master Dispatcher: BGProcessingTaskRequest (requiresNetwork=$desiredRequiresNetwork)")
                 val masterRequest = BGProcessingTaskRequest(MASTER_DISPATCHER_IDENTIFIER).apply {
-                    requiresNetworkConnectivity = false
+                    requiresNetworkConnectivity = desiredRequiresNetwork
                     requiresExternalPower = false
-                    earliestBeginDate = proposedDate
+                    this.earliestBeginDate = earliestBeginDate
                 }
 
                 return submitTaskRequest(masterRequest, "Master Dispatcher for task '$id'")

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/MasterDispatcherConstraintSummaryTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/MasterDispatcherConstraintSummaryTest.kt
@@ -1,0 +1,148 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
+package dev.brewkits.kmpworkmanager
+
+import dev.brewkits.kmpworkmanager.background.data.*
+import kotlinx.coroutines.test.runTest
+import platform.Foundation.*
+import kotlin.test.*
+
+/**
+ * Covers [IosFileStorage.getDynamicQueueConstraintSummary] — the aggregate
+ * light/network profile the Master Dispatcher uses to pick between an unconstrained
+ * `BGProcessingTaskRequest` and a cheaper, better-scheduled `BGAppRefreshTaskRequest`.
+ *
+ * Background: raised in
+ * https://github.com/brewkits/kmpworkmanager/discussions/78 and tracked as
+ * https://github.com/brewkits/kmpworkmanager/issues/79 — the dispatcher previously
+ * always requested an unconstrained `BGProcessingTaskRequest`, even when every pending
+ * dynamic task was light and network-dependent. See
+ * docs/ios-dynamic-task-scheduling.md § 5.
+ */
+class MasterDispatcherConstraintSummaryTest {
+
+    private fun makeTempDir(tag: String): NSURL {
+        val base = NSTemporaryDirectory()
+        val name = "kmp_master_dispatcher_summary_${tag}_${(NSDate().timeIntervalSince1970 * 1000).toLong()}_${platform.posix.rand()}"
+        val url = NSURL.fileURLWithPath("$base$name")
+        NSFileManager.defaultManager.createDirectoryAtURL(url, withIntermediateDirectories = true, attributes = null, error = null)
+        return url
+    }
+
+    private fun makeStorage(tag: String): IosFileStorage {
+        return IosFileStorage(
+            config = IosFileStorageConfig(isTestMode = true),
+            baseDirectory = makeTempDir(tag)
+        )
+    }
+
+    private fun metaFor(requiresNetwork: Boolean, isHeavyTask: Boolean): Map<String, String> = mapOf(
+        "workerClassName" to "EchoWorker",
+        "requiresNetwork" to "$requiresNetwork",
+        "requiresCharging" to "false",
+        "isHeavyTask" to "$isHeavyTask"
+    )
+
+    @Test
+    fun `empty queue reports no pending tasks and is not all-light or all-network`() = runTest {
+        val storage = makeStorage("empty")
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(0, summary.pendingCount)
+        assertFalse(summary.allLight, "an empty queue has nothing to schedule as BGAppRefreshTask")
+        assertFalse(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `queue of only light network tasks is reported all-light and all-network`() = runTest {
+        val storage = makeStorage("all-light-network")
+
+        storage.enqueueTask("light-net-1")
+        storage.saveTaskMetadata("light-net-1", metaFor(requiresNetwork = true, isHeavyTask = false), periodic = false)
+        storage.enqueueTask("light-net-2")
+        storage.saveTaskMetadata("light-net-2", metaFor(requiresNetwork = true, isHeavyTask = false), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(2, summary.pendingCount)
+        assertTrue(summary.allLight, "all queued tasks are light — dispatcher should use BGAppRefreshTaskRequest")
+        assertTrue(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `a single heavy task among light ones flips allLight to false`() = runTest {
+        val storage = makeStorage("mixed-heavy")
+
+        storage.enqueueTask("light-1")
+        storage.saveTaskMetadata("light-1", metaFor(requiresNetwork = false, isHeavyTask = false), periodic = false)
+        storage.enqueueTask("heavy-1")
+        storage.saveTaskMetadata("heavy-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(2, summary.pendingCount)
+        assertFalse(summary.allLight, "one heavy task in the queue means BGProcessingTaskRequest is still required")
+    }
+
+    @Test
+    fun `mixed network requirements are not reported as all-network`() = runTest {
+        val storage = makeStorage("mixed-network")
+
+        storage.enqueueTask("net-1")
+        storage.saveTaskMetadata("net-1", metaFor(requiresNetwork = true, isHeavyTask = true), periodic = false)
+        storage.enqueueTask("offline-ok-1")
+        storage.saveTaskMetadata("offline-ok-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertFalse(
+            summary.allRequireNetwork,
+            "requiresNetworkConnectivity=true would wrongly block the offline-capable task too"
+        )
+    }
+
+    @Test
+    fun `periodic dynamic task metadata is also aggregated`() = runTest {
+        val storage = makeStorage("periodic")
+
+        storage.enqueueTask("periodic-light")
+        storage.saveTaskMetadata(
+            "periodic-light",
+            mapOf(
+                "isPeriodic" to "true",
+                "intervalMs" to "60000",
+                "anchoredStartMs" to "0",
+                "workerClassName" to "EchoWorker",
+                "requiresNetwork" to "true",
+                "requiresCharging" to "false",
+                "isHeavyTask" to "false"
+            ),
+            periodic = true
+        )
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(1, summary.pendingCount)
+        assertTrue(summary.allLight)
+        assertTrue(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `dequeued tasks drop out of the aggregate`() = runTest {
+        val storage = makeStorage("dequeue")
+
+        storage.enqueueTask("heavy-1")
+        storage.saveTaskMetadata("heavy-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+        storage.enqueueTask("light-1")
+        storage.saveTaskMetadata("light-1", metaFor(requiresNetwork = false, isHeavyTask = false), periodic = false)
+
+        assertFalse(storage.getDynamicQueueConstraintSummary().allLight)
+
+        assertEquals("heavy-1", storage.dequeueTask())
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+        assertEquals(1, summary.pendingCount)
+        assertTrue(summary.allLight, "after the heavy task is dequeued, only the light task remains")
+    }
+}


### PR DESCRIPTION
## What

Derives the iOS dynamic-task master dispatcher's `requiresNetworkConnectivity` from the pending queue instead of hardcoding `false`. Raised in #78, tracked as #79.

## Why

The master dispatcher (`kmp_master_dispatcher_task`) always submitted an unconstrained `BGProcessingTaskRequest`, regardless of what was actually queued. A queue full of light, network-dependent tasks would still wake the app opportunistically while offline, fail every task locally (no connectivity), and re-queue them — wasted execution windows.

## What changed

- `IosFileStorage.getDynamicQueueConstraintSummary()`: O(N) aggregate of `isHeavyTask`/`requiresNetwork` across pending dynamic tasks, via `AppendOnlyQueue.getAllItems()` (non-destructive, already used by the chain queue's `getActiveChainIds()`).
- `NativeTaskScheduler.submitTaskRequest()` / `DynamicTaskDispatcher.rescheduleMasterDispatcher()`: set `requiresNetworkConnectivity = true` only when every pending dynamic task requires network. Re-derives the flag on an already-pending master request when the aggregate profile changes, without regressing an earlier `earliestBeginDate`.
- `docs/ios-dynamic-task-scheduling.md` § 5 and `docs/IOS_BGTASK_LIMITS.md` § 6: document the behavior and why the dispatcher's request *type* stays `BGProcessingTaskRequest`.
- New test: `MasterDispatcherConstraintSummaryTest` (6 cases — empty queue, all-light+network, mixed-heavy, mixed-network, periodic tasks, dequeue drops out of the aggregate).

## Deliberately NOT in this PR

Switching the dispatcher to `BGAppRefreshTaskRequest` when every pending task is light (the original ask in #78) — investigated and found unsafe with the current batch executor: `BGAppRefreshTask`'s hard ~30s ceiling (no extension API) leaves no margin against a single dequeued task's 25s timeout (`SingleTaskExecutor.DEFAULT_TIMEOUT_MS`), let alone a batch. Static-ID light tasks are unaffected. Remaining scope tracked in #79.

## Testing

`./gradlew :kmpworker:iosSimulatorArm64Test` — full suite green (887+ tests), including the new test class.
