### PR TITLE
feat(http): HMAC-SHA256 request signing + token refresh on 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See the [changelog](CHANGELOG.md) for the full history, and the per-version upgr
 
 | Worker | Status | Notes |
 |--------|--------|-------|
-| `HttpRequestWorker` | Stable | One-shot HTTP with configurable method, headers, body. SSRF-validated. |
+| `HttpRequestWorker` | Stable | One-shot HTTP with configurable method, headers, body. SSRF-validated. Optional `HmacSigningConfig` (HMAC-SHA256 request signing, GitHub-webhook-style prefix support) and `TokenRefreshConfig` (auto-refresh + one-shot retry on `401`, dot-notation token extraction from the refresh response). |
 | `HttpDownloadWorker` | Stable (v2.5+) | Resumable download via HTTP `Range`. `<savePath>.partial` survives process kill; a process kill resumes from last byte. Supports SHA-256/SHA-1/SHA-512/MD5 checksum verification and `DuplicatePolicy` (overwrite / skip / rename). |
 | `ParallelHttpDownloadWorker` | Stable | Splits a single file into N (1..16, default 4) HTTP `Range` chunks downloaded concurrently with per-chunk `.partN` resume. Automatic sequential fallback when the server does not advertise `Accept-Ranges: bytes`. Same checksum verification surface as `HttpDownloadWorker`. |
 | `HttpUploadWorker` | ⚠️ Experimental | Streaming multipart upload. No resumable / chunked upload yet (see `ParallelHttpUploadWorker` for multi-file uploads). |

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/builtins/HttpRequestWorker.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/builtins/HttpRequestWorker.kt
@@ -9,6 +9,8 @@ import dev.brewkits.kmpworkmanager.workers.config.HttpMethod as WorkerHttpMethod
 import dev.brewkits.kmpworkmanager.workers.config.HttpRequestConfig
 import dev.brewkits.kmpworkmanager.workers.utils.HttpClientProvider
 import dev.brewkits.kmpworkmanager.workers.utils.SecurityValidator
+import dev.brewkits.kmpworkmanager.workers.utils.applyHmacSigning
+import dev.brewkits.kmpworkmanager.workers.utils.executeWithTokenRefresh
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -41,6 +43,16 @@ class HttpRequestWorker(
                 return WorkerResult.Failure("Invalid or unsafe URL")
             }
 
+            // TokenRefreshConfig.refreshUrl is a second outbound destination this worker
+            // calls directly — it must pass the same SSRF gate as the primary URL, not
+            // just the http(s):// prefix check TokenRefreshConfig.init does.
+            config.tokenRefresh?.let { refresh ->
+                if (!SecurityValidator.validateURL(refresh.refreshUrl)) {
+                    Logger.e("HttpRequestWorker", "Invalid or unsafe refresh URL: ${SecurityValidator.sanitizedURL(refresh.refreshUrl)}")
+                    return WorkerResult.Failure("Invalid or unsafe refresh URL")
+                }
+            }
+
             Logger.i("HttpRequestWorker", "Executing ${config.httpMethod} request to ${SecurityValidator.sanitizedURL(config.url)}")
 
             executeRequest(httpClient, config)
@@ -52,29 +64,57 @@ class HttpRequestWorker(
 
     private suspend fun executeRequest(client: HttpClient, config: HttpRequestConfig): WorkerResult {
         return try {
-            val response: HttpResponse = client.request(config.url) {
-                method = when (config.httpMethod) {
-                    WorkerHttpMethod.GET -> HttpMethod.Get
-                    WorkerHttpMethod.POST -> HttpMethod.Post
-                    WorkerHttpMethod.PUT -> HttpMethod.Put
-                    WorkerHttpMethod.DELETE -> HttpMethod.Delete
-                    WorkerHttpMethod.PATCH -> HttpMethod.Patch
-                }
+            val response: HttpResponse = executeWithTokenRefresh(client, config.tokenRefresh) { newToken ->
+                client.request(config.url) {
+                    method = when (config.httpMethod) {
+                        WorkerHttpMethod.GET -> HttpMethod.Get
+                        WorkerHttpMethod.POST -> HttpMethod.Post
+                        WorkerHttpMethod.PUT -> HttpMethod.Put
+                        WorkerHttpMethod.DELETE -> HttpMethod.Delete
+                        WorkerHttpMethod.PATCH -> HttpMethod.Patch
+                    }
 
-                timeout {
-                    requestTimeoutMillis = config.timeoutMs
-                    connectTimeoutMillis = config.timeoutMs
-                    socketTimeoutMillis = config.timeoutMs
-                }
+                    timeout {
+                        requestTimeoutMillis = config.timeoutMs
+                        connectTimeoutMillis = config.timeoutMs
+                        socketTimeoutMillis = config.timeoutMs
+                    }
 
-                SecurityValidator.sanitizeHeaders(config.headers)?.forEach { (key, value) ->
-                    header(key, value)
-                }
+                    SecurityValidator.sanitizeHeaders(config.headers)?.forEach { (key, value) ->
+                        header(key, value)
+                    }
 
-                // Set body for POST/PUT/PATCH
-                if (config.body != null && config.httpMethod in setOf(WorkerHttpMethod.PUT, WorkerHttpMethod.PATCH, WorkerHttpMethod.POST)) {
-                    setBody(config.body)
-                    contentType(ContentType.Application.Json)
+                    // Set body for POST/PUT/PATCH. Body-bearing methods only — a body sent
+                    // in the config for GET/DELETE is never written to the wire, and must
+                    // therefore also be excluded from what gets signed below.
+                    val sendsBody = config.httpMethod in setOf(WorkerHttpMethod.PUT, WorkerHttpMethod.PATCH, WorkerHttpMethod.POST)
+                    val bodyOnWire = config.body.takeIf { sendsBody }
+                    if (bodyOnWire != null) {
+                        setBody(bodyOnWire)
+                        contentType(ContentType.Application.Json)
+                    }
+
+                    // A retried request (newToken != null) overrides whatever Authorization
+                    // config.headers set above — the refreshed token is what must be sent.
+                    // `header()` APPENDS (Ktor's HeadersBuilder), so the stale value set
+                    // above must be removed first or the request would carry both.
+                    val tokenRefresh = config.tokenRefresh
+                    if (newToken != null && tokenRefresh != null) {
+                        headers.remove(tokenRefresh.authHeaderName)
+                        header(tokenRefresh.authHeaderName, "${tokenRefresh.authHeaderPrefix}$newToken")
+                    }
+
+                    // NOTE: computeHmacSignature signs METHOD/URL/BODY/TIMESTAMP only — it
+                    // does NOT cover headers, so a refreshed Authorization header above is
+                    // NOT part of what's signed. What DOES differ between the original and
+                    // retried attempt is the timestamp (recomputed per call), so the two
+                    // signatures differ even though the covered fields are otherwise the same.
+                    // bodyOnWire (not config.body) — must match exactly what setBody sent,
+                    // so a GET/DELETE with a config.body that's never written to the wire
+                    // doesn't sign bytes the server will never see.
+                    config.hmacSigning?.let { signingConfig ->
+                        applyHmacSigning(config.httpMethod.name, config.url, bodyOnWire, signingConfig)
+                    }
                 }
             }
 

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigning.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigning.kt
@@ -1,0 +1,64 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.utils.currentTimeMillis
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import okio.ByteString.Companion.encodeUtf8
+
+/**
+ * Computes the HMAC-SHA256 signature for the canonical string `METHOD\nURL\nBODY\nTIMESTAMP`.
+ *
+ * Pure function — no I/O, no Ktor dependency beyond the config type — so it's testable
+ * without a live or mocked HTTP client. [HmacSigningConfig.signBody]/[HmacSigningConfig.includeTimestamp]
+ * control whether [body]/[timestamp] contribute to the canonical string (an omitted
+ * component is an empty line, not a removed one, so the line count — and therefore the
+ * signature — always reflects which components are enabled).
+ *
+ * Uses Okio's built-in `ByteString.hmacSha256` (no platform-specific crypto needed —
+ * Okio implements HMAC-SHA256 natively on every KMP target this library supports).
+ *
+ * @return the hex-encoded signature, prefixed with [HmacSigningConfig.signaturePrefix] if set.
+ */
+internal fun computeHmacSignature(
+    method: String,
+    url: String,
+    body: String?,
+    timestamp: String?,
+    config: HmacSigningConfig
+): String {
+    val canonical = buildString {
+        append(method.uppercase())
+        append('\n')
+        append(url)
+        append('\n')
+        append(if (config.signBody) body.orEmpty() else "")
+        append('\n')
+        append(timestamp.orEmpty())
+    }
+    val digest = canonical.encodeUtf8()
+        .hmacSha256(config.secretKey.encodeUtf8())
+        .hex()
+    return config.signaturePrefix?.let { it + digest } ?: digest
+}
+
+/**
+ * Applies [HmacSigningConfig] to this request builder: computes the signature (and, when
+ * [HmacSigningConfig.includeTimestamp] is set, the timestamp used in it) and adds the
+ * corresponding header(s). Call this **after** every other header/body mutation on
+ * [this] builder — the signature must cover the final outgoing request, not an
+ * intermediate state.
+ */
+internal fun HttpRequestBuilder.applyHmacSigning(
+    method: String,
+    url: String,
+    body: String?,
+    config: HmacSigningConfig
+) {
+    val timestamp = if (config.includeTimestamp) currentTimeMillis().toString() else null
+    val signature = computeHmacSignature(method, url, body, timestamp, config)
+    header(config.headerName, signature)
+    if (timestamp != null) {
+        header(config.timestampHeaderName, timestamp)
+    }
+}

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefresh.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefresh.kt
@@ -1,0 +1,105 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.utils.Logger
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val TAG = "TokenRefresh"
+
+/**
+ * Executes [request] (the original request); if it comes back `401` and [config] is
+ * non-null, refreshes the token via [config] and retries [request] **exactly once** with
+ * the new token. Never loops: a still-401 retry response, a failed/non-2xx refresh call,
+ * or a refresh response body that doesn't contain [TokenRefreshConfig.tokenResponsePath]
+ * are all returned/passed through as the final result rather than retrying again.
+ *
+ * @param request Executes and returns the original request. Receives the new token (or
+ *   `null` on the first call) so the caller can inject it into the appropriate header —
+ *   this function does not assume where in the request the auth header lives beyond what
+ *   [TokenRefreshConfig.authHeaderName] says, since the caller may also need to re-apply
+ *   HMAC signing over the refreshed header.
+ */
+internal suspend fun executeWithTokenRefresh(
+    client: HttpClient,
+    config: TokenRefreshConfig?,
+    request: suspend (newToken: String?) -> HttpResponse
+): HttpResponse {
+    val first = request(null)
+    if (config == null || first.status != HttpStatusCode.Unauthorized) return first
+
+    val newToken = refreshToken(client, config)
+    if (newToken == null) {
+        Logger.w(TAG, "Token refresh failed or returned no usable token — returning original 401")
+        return first
+    }
+
+    Logger.i(TAG, "Token refreshed — retrying original request once")
+    return request(newToken)
+}
+
+private suspend fun refreshToken(client: HttpClient, config: TokenRefreshConfig): String? {
+    // Belt-and-suspenders SSRF gate: HttpRequestWorker validates refreshUrl in doWork()
+    // before this ever runs, but that gate lives in the caller, not here. Checking again
+    // makes this function safe by construction for any future caller (HttpSyncWorker,
+    // HttpUploadWorker, …) that adopts TokenRefreshConfig without remembering to
+    // replicate the same check — the exact drift class fixed in installSecureRedirectFollowing().
+    if (!SecurityValidator.validateURL(config.refreshUrl)) {
+        Logger.e(TAG, "Refusing to call unsafe refresh URL: ${SecurityValidator.sanitizedURL(config.refreshUrl)}")
+        return null
+    }
+    return try {
+        val response = client.request(config.refreshUrl) {
+            method = HttpMethod.parse(config.refreshMethod)
+            config.refreshHeaders?.forEach { (key, value) -> header(key, value) }
+            if (config.refreshBody != null) {
+                setBody(config.refreshBody)
+                contentType(ContentType.Application.Json)
+            }
+        }
+        if (response.status.value !in 200..299) {
+            Logger.w(TAG, "Refresh endpoint returned ${response.status.value} — not retrying original request")
+            return null
+        }
+        val json = Json.parseToJsonElement(response.bodyAsText())
+        // Blank counts as "no usable token" — an empty access_token would otherwise send
+        // "Authorization: Bearer " on retry, a request the server will reject anyway but
+        // that masks the real failure (a malformed/incomplete refresh response) behind a
+        // second, misleading 401.
+        extractByDotPath(json, config.tokenResponsePath)?.takeUnless { it.isBlank() }
+    } catch (e: Exception) {
+        Logger.e(TAG, "Token refresh call to ${SecurityValidator.sanitizedURL(config.refreshUrl)} failed", e)
+        null
+    }
+}
+
+/**
+ * Navigates [root] through [path]'s dot-separated keys (e.g. `"auth.access_token"` into
+ * `{"auth":{"access_token":"..."}}`) and returns the string content of the value found
+ * there, or `null` if any segment is missing, not an object, or the final value isn't a
+ * JSON string/primitive.
+ */
+internal fun extractByDotPath(root: JsonElement, path: String): String? {
+    var current: JsonElement = root
+    for (key in path.split('.')) {
+        val obj = current as? JsonObject ?: return null
+        current = obj[key] ?: return null
+    }
+    val primitive = current as? JsonPrimitive ?: return null
+    return primitive.takeUnless { it == kotlinx.serialization.json.JsonNull }?.let {
+        runCatching { it.jsonPrimitive.content }.getOrNull()
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/HttpRequestSigningAndTokenRefreshTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/HttpRequestSigningAndTokenRefreshTest.kt
@@ -1,0 +1,265 @@
+package dev.brewkits.kmpworkmanager.workers
+
+import dev.brewkits.kmpworkmanager.background.domain.WorkerEnvironment
+import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
+import dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import dev.brewkits.kmpworkmanager.workers.config.HttpRequestConfig
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import dev.brewkits.kmpworkmanager.workers.utils.HttpWorkerJson
+import dev.brewkits.kmpworkmanager.workers.utils.computeHmacSignature
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for [HttpRequestWorker]'s HMAC signing ([HmacSigningConfig]) and
+ * token-refresh-on-401 ([TokenRefreshConfig]) integration — issues #78/#81.
+ */
+class HttpRequestSigningAndTokenRefreshTest {
+
+    private fun mockClient(engine: MockEngine) = HttpClient(engine) { install(HttpTimeout) }
+
+    // ==================== HMAC signing ====================
+
+    @Test
+    fun hmacSigning_addsSignatureAndTimestampHeaders_matchingIndependentComputation() = runTest {
+        var observedSignature: String? = null
+        var observedTimestamp: String? = null
+        val mock = MockEngine { request ->
+            observedSignature = request.headers["X-Signature"]
+            observedTimestamp = request.headers["X-Timestamp"]
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef")
+        val config = HttpRequestConfig(url = "https://api.example.com/things", method = "POST", body = "payload", hmacSigning = signing)
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Success, "expected Success, got: $result")
+        assertNotNull(observedSignature, "X-Signature header must be present")
+        assertNotNull(observedTimestamp, "X-Timestamp header must be present when includeTimestamp is true (default)")
+        val expected = computeHmacSignature("POST", config.url, config.body, observedTimestamp, signing)
+        assertEquals(expected, observedSignature, "signature must match independently recomputing over the same inputs")
+    }
+
+    @Test
+    fun hmacSigning_includeTimestampFalse_omitsTimestampHeader() = runTest {
+        var sawTimestampHeader = false
+        val mock = MockEngine { request ->
+            sawTimestampHeader = request.headers.contains("X-Timestamp")
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef", includeTimestamp = false)
+        val config = HttpRequestConfig(url = "https://api.example.com/things", hmacSigning = signing)
+
+        worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(!sawTimestampHeader)
+    }
+
+    // ==================== Token refresh ====================
+
+    @Test
+    fun tokenRefresh_on401_refreshesAndRetriesOnce_thenSucceeds() = runTest {
+        var callCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> {
+                    callCount++
+                    respond(
+                        content = """{"auth":{"access_token":"new-token-123"}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.headers[HttpHeaders.Authorization] == "Bearer new-token-123" -> {
+                    callCount++
+                    respond(content = "protected data", status = HttpStatusCode.OK)
+                }
+                else -> {
+                    callCount++
+                    respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val refresh = TokenRefreshConfig(
+            refreshUrl = "https://api.example.com/refresh",
+            tokenResponsePath = "auth.access_token"
+        )
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            headers = mapOf("Authorization" to "Bearer stale-token"),
+            tokenRefresh = refresh
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Success, "expected Success after refresh+retry, got: $result")
+        assertEquals(3, callCount, "expected exactly 3 calls: original 401, refresh, retried request")
+    }
+
+    @Test
+    fun tokenRefresh_stillUnauthorizedAfterRetry_doesNotLoop() = runTest {
+        var protectedCallCount = 0
+        var refreshCallCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> {
+                    refreshCallCount++
+                    respond(
+                        content = """{"access_token":"new-token"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> {
+                    protectedCallCount++
+                    respond(content = "still unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure, "still-401 after retry must surface as Failure, got: $result")
+        assertEquals(1, refreshCallCount, "refresh must be attempted exactly once — no retry loop")
+        assertEquals(2, protectedCallCount, "protected endpoint hit exactly twice: original + one retry")
+    }
+
+    @Test
+    fun tokenRefresh_refreshEndpointFails_returnsOriginal401_withoutRetrying() = runTest {
+        var protectedCallCount = 0
+        val mock = MockEngine { request ->
+            if (request.url.encodedPath == "/refresh") {
+                respond(content = "server error", status = HttpStatusCode.InternalServerError)
+            } else {
+                protectedCallCount++
+                respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, protectedCallCount, "must not retry the original request when refresh itself failed")
+    }
+
+    @Test
+    fun noTokenRefreshConfig_401PassesThroughUnchanged_noRefreshCallAttempted() = runTest {
+        var callCount = 0
+        val mock = MockEngine { _ ->
+            callCount++
+            respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(url = "https://api.example.com/protected") // tokenRefresh = null
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, callCount, "with no tokenRefresh config, exactly one call — no refresh attempted")
+    }
+
+    @Test
+    fun tokenRefresh_ssrfBlockedRefreshUrl_failsBeforeAnyRequest() = runTest {
+        var callCount = 0
+        // MockEngine that fails the test if invoked — proves the SSRF gate on refreshUrl
+        // rejects the config before ANY network call, primary request included.
+        val mock = MockEngine { _ ->
+            callCount++
+            respond(content = "should not be called", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            // Cloud-metadata link-local address — the same one BuiltinWorkersTest uses to
+            // pin SecurityValidator's SSRF blocklist for the primary URL.
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "http://169.254.169.254/latest/meta-data/")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals("Invalid or unsafe refresh URL", result.message)
+        assertEquals(0, callCount, "no request — neither primary nor refresh — may be issued when refreshUrl is SSRF-blocked")
+    }
+
+    @Test
+    fun tokenRefresh_blankToken_treatedAsFailedRefresh_doesNotRetryWithEmptyBearer() = runTest {
+        var protectedCallCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> respond(
+                    content = """{"access_token":""}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+                else -> {
+                    protectedCallCount++
+                    assertTrue(
+                        request.headers[HttpHeaders.Authorization] != "Bearer ",
+                        "must never send an empty-token Authorization header"
+                    )
+                    respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, protectedCallCount, "a blank refreshed token must not trigger a retry")
+    }
+
+    // ==================== HMAC signing does not cover the request body on GET ====================
+
+    @Test
+    fun hmacSigning_getRequestWithConfigBody_signatureExcludesBody_sinceBodyIsNeverSent() = runTest {
+        var observedSignature: String? = null
+        var observedTimestamp: String? = null
+        val mock = MockEngine { request ->
+            observedSignature = request.headers["X-Signature"]
+            observedTimestamp = request.headers["X-Timestamp"]
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef")
+        // GET with a body: HttpRequestWorker never calls setBody for GET, so the signature
+        // must be computed as if body were null — not over this (unsent) value.
+        val config = HttpRequestConfig(url = "https://api.example.com/things", method = "GET", body = "never-sent", hmacSigning = signing)
+
+        worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        val expected = computeHmacSignature("GET", config.url, null, observedTimestamp, signing)
+        assertEquals(expected, observedSignature)
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigningTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigningTest.kt
@@ -1,0 +1,88 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [computeHmacSignature] — pure-function coverage, no HTTP client involved.
+ *
+ * The known-vector test pins the exact canonical-string format (`METHOD\nURL\nBODY\nTIMESTAMP`)
+ * against an independently computed HMAC-SHA256 digest, so a future refactor that
+ * accidentally reorders or drops a line breaks loudly instead of just changing the output
+ * silently (both sides of a client/server pair must agree on the exact canonical format).
+ */
+class HmacRequestSigningTest {
+
+    private val secret = "0123456789abcdef" // exactly 16 chars — the minimum allowed
+
+    // HMAC-SHA256("0123456789abcdef", "POST\nhttps://api.example.com/upload\nhello\n1700000000000")
+    // computed independently via Python's hmac/hashlib for cross-check.
+    private val knownVectorSignature = "72cadd50011f98595398c334c9543dc53380f430ec5355a7823a66c2ef46d9fd".let {
+        // Guard against a typo in the constant above breaking every test with a confusing
+        // "expected 64 chars" failure far from the actual assertion.
+        require(it.length == 64) { "test constant must be a 64-char SHA-256 hex digest" }
+        it
+    }
+
+    @Test
+    fun knownVector_matchesIndependentlyComputedDigest() {
+        val config = HmacSigningConfig(secretKey = secret)
+
+        val signature = computeHmacSignature(
+            method = "post", // lowercase on purpose — canonical form uppercases it
+            url = "https://api.example.com/upload",
+            body = "hello",
+            timestamp = "1700000000000",
+            config = config
+        )
+
+        assertEquals(knownVectorSignature, signature)
+    }
+
+    @Test
+    fun signaturePrefix_isPrependedToTheHexDigest() {
+        val config = HmacSigningConfig(secretKey = secret, signaturePrefix = "sha256=")
+
+        val signature = computeHmacSignature("POST", "https://x", "body", "123", config)
+
+        assertTrue(signature.startsWith("sha256="))
+        assertEquals("sha256=" + computeHmacSignature("POST", "https://x", "body", "123", config.copy(signaturePrefix = null)), signature)
+    }
+
+    @Test
+    fun signBodyFalse_ignoresBodyDifferences() {
+        val config = HmacSigningConfig(secretKey = secret, signBody = false)
+
+        val withBodyA = computeHmacSignature("POST", "https://x", "body-a", "123", config)
+        val withBodyB = computeHmacSignature("POST", "https://x", "body-b", "123", config)
+
+        assertEquals(withBodyA, withBodyB, "signBody=false must make the signature independent of the body content")
+    }
+
+    @Test
+    fun signBodyTrue_differsAcrossBodies() {
+        val config = HmacSigningConfig(secretKey = secret, signBody = true)
+
+        val withBodyA = computeHmacSignature("POST", "https://x", "body-a", "123", config)
+        val withBodyB = computeHmacSignature("POST", "https://x", "body-b", "123", config)
+
+        assertNotEquals(withBodyA, withBodyB)
+    }
+
+    @Test
+    fun differentSecretKeys_produceDifferentSignatures() {
+        val a = computeHmacSignature("POST", "https://x", "body", "123", HmacSigningConfig(secretKey = "aaaaaaaaaaaaaaaa"))
+        val b = computeHmacSignature("POST", "https://x", "body", "123", HmacSigningConfig(secretKey = "bbbbbbbbbbbbbbbb"))
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun secretKeyUnder16Chars_isRejectedAtConstruction() {
+        val error = kotlin.runCatching { HmacSigningConfig(secretKey = "short") }.exceptionOrNull()
+        assertTrue(error is IllegalArgumentException, "expected construction to fail, got: $error")
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefreshTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefreshTest.kt
@@ -1,0 +1,114 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pure-function coverage for [extractByDotPath] — no HTTP client involved.
+ */
+class TokenRefreshTest {
+
+    private fun json(text: String) = Json.parseToJsonElement(text)
+
+    @Test
+    fun topLevelKey_extractsDirectly() {
+        assertEquals("abc123", extractByDotPath(json("""{"access_token":"abc123"}"""), "access_token"))
+    }
+
+    @Test
+    fun nestedKey_navigatesThroughDots() {
+        assertEquals("abc123", extractByDotPath(json("""{"auth":{"access_token":"abc123"}}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun deeplyNestedKey_navigatesThroughMultipleLevels() {
+        val doc = json("""{"a":{"b":{"c":{"d":"deep-value"}}}}""")
+        assertEquals("deep-value", extractByDotPath(doc, "a.b.c.d"))
+    }
+
+    @Test
+    fun missingKey_atTopLevel_returnsNull() {
+        assertNull(extractByDotPath(json("""{"other":"x"}"""), "access_token"))
+    }
+
+    @Test
+    fun missingKey_partwayThroughPath_returnsNull() {
+        assertNull(extractByDotPath(json("""{"auth":{"other":"x"}}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun nonObjectMidPath_returnsNull_ratherThanThrowing() {
+        // "auth" is a string, not an object — trying to navigate ".access_token" into it
+        // must fail gracefully, not throw a ClassCastException from a malformed/unexpected
+        // refresh response shape.
+        assertNull(extractByDotPath(json("""{"auth":"not-an-object"}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun jsonNullValue_returnsNull() {
+        assertNull(extractByDotPath(json("""{"access_token":null}"""), "access_token"))
+    }
+
+    @Test
+    fun numericValue_returnsItsStringContent() {
+        // Some backends return a numeric token/ID; JsonPrimitive.content still yields its
+        // textual form, so this is treated as usable rather than silently failing.
+        assertEquals("12345", extractByDotPath(json("""{"access_token":12345}"""), "access_token"))
+    }
+
+    @Test
+    fun arrayValue_returnsNull_notAToStringDump() {
+        assertNull(extractByDotPath(json("""{"access_token":["a","b"]}"""), "access_token"))
+    }
+
+    @Test
+    fun emptyPath_returnsNull() {
+        assertNull(extractByDotPath(json("""{"access_token":"abc"}"""), ""))
+    }
+
+    // ==================== executeWithTokenRefresh: SSRF gate is inside refreshToken(), ====================
+    // ==================== not only in HttpRequestWorker.doWork() ====================
+
+    /**
+     * Calls [executeWithTokenRefresh] directly — bypassing `HttpRequestWorker.doWork()`'s
+     * own `validateURL(refreshUrl)` check entirely — to prove the gate inside
+     * `refreshToken()` itself rejects an SSRF-blocked refresh URL. A test that only went
+     * through `HttpRequestWorker` would pass on the location of the check, not the check;
+     * this pins the check at the layer any future `TokenRefreshConfig` caller shares.
+     */
+    @Test
+    fun executeWithTokenRefresh_ssrfBlockedRefreshUrl_neverCallsRefreshEndpoint() = runTest {
+        var refreshEndpointCallCount = 0
+        val mock = MockEngine { request ->
+            if (request.url.host == "169.254.169.254") {
+                refreshEndpointCallCount++
+                respond(content = "should never be reached", status = HttpStatusCode.OK)
+            } else {
+                respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+            }
+        }
+        val client = HttpClient(mock) { install(HttpTimeout) }
+        val config = TokenRefreshConfig(refreshUrl = "http://169.254.169.254/latest/meta-data/")
+
+        var originalRequestCallCount = 0
+        val response: HttpResponse = executeWithTokenRefresh(client, config) {
+            originalRequestCallCount++
+            client.request("https://api.example.com/protected") { }
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status, "original 401 must be returned when refresh is blocked")
+        assertEquals(0, refreshEndpointCallCount, "refreshToken() must reject the SSRF-blocked URL before any HTTP call")
+        assertEquals(1, originalRequestCallCount, "no retry — refresh never produced a token")
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HmacSigningConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HmacSigningConfig.kt
@@ -1,0 +1,59 @@
+package dev.brewkits.kmpworkmanager.workers.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * HMAC-SHA256 request signing, applied by [dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker]
+ * before a request is sent. Mirrors the Flutter `native_workmanager` `request_signing.dart`
+ * config so a payload shared between the two scheduling layers parses identically.
+ *
+ * The canonical string signed is:
+ * ```
+ * METHOD\nURL\nBODY\nTIMESTAMP
+ * ```
+ * where `BODY` is empty when [signBody] is `false`, and `TIMESTAMP` is empty when
+ * [includeTimestamp] is `false`. The signature is HMAC-SHA256([secretKey], canonical),
+ * hex-encoded, and sent in the [headerName] header (optionally prefixed by
+ * [signaturePrefix] — e.g. `"sha256="` for GitHub-webhook-style signatures).
+ *
+ * **Security note:** [secretKey] is persisted as part of the worker's task input (same as
+ * any `Authorization` header value passed via `HttpRequestConfig.headers` today) so it
+ * survives process death for retries. Do not use a key that must never touch disk.
+ *
+ * @property secretKey The HMAC signing key. Minimum 16 characters — a shorter key is
+ *   rejected at construction time rather than producing a weak, easily brute-forced signature.
+ * @property headerName Header the computed signature is sent in. Default `"X-Signature"`.
+ * @property signaturePrefix Optional prefix prepended to the hex signature before it's
+ *   placed in [headerName] — e.g. `"sha256="` to match GitHub webhook signature format.
+ *   `null` (default) sends the raw hex digest with no prefix.
+ * @property signBody When `true` (default), the request body is included in the canonical
+ *   string. Set `false` for GET/DELETE requests with no body, or when the body is streamed
+ *   and unavailable at signing time.
+ * @property includeTimestamp When `true` (default), a millisecond epoch timestamp is
+ *   included in the canonical string and also sent in [timestampHeaderName], letting the
+ *   receiving server reject stale/replayed requests. Set `false` for servers whose
+ *   canonical format has no timestamp component.
+ * @property timestampHeaderName Header the timestamp is sent in when [includeTimestamp] is
+ *   `true`. Default `"X-Timestamp"`.
+ */
+@Serializable
+data class HmacSigningConfig(
+    val secretKey: String,
+    val headerName: String = "X-Signature",
+    val signaturePrefix: String? = null,
+    val signBody: Boolean = true,
+    val includeTimestamp: Boolean = true,
+    val timestampHeaderName: String = "X-Timestamp"
+) {
+    init {
+        require(secretKey.length >= 16) {
+            "secretKey must be at least 16 characters, got ${secretKey.length}"
+        }
+        require(headerName.isNotBlank()) {
+            "headerName must not be blank"
+        }
+        require(timestampHeaderName.isNotBlank()) {
+            "timestampHeaderName must not be blank"
+        }
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HttpRequestConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HttpRequestConfig.kt
@@ -10,6 +10,13 @@ import kotlinx.serialization.Serializable
  * @property headers Optional HTTP headers
  * @property body Optional request body (for POST, PUT, PATCH)
  * @property timeoutMs Request timeout in milliseconds (default: 30000ms = 30s)
+ * @property hmacSigning Optional HMAC-SHA256 request signing — see [HmacSigningConfig]. The
+ *   signature covers `METHOD`/`URL`/`BODY`/`TIMESTAMP` only, **not headers** — it does not
+ *   cover [headers] or a refreshed `Authorization` header from [tokenRefresh].
+ * @property tokenRefresh Optional automatic token refresh on `401` — see
+ *   [TokenRefreshConfig]. When [hmacSigning] is also set, the retried request is re-signed
+ *   with a fresh timestamp (so its signature differs from the original attempt's), but the
+ *   signature still does not cover the refreshed `Authorization` header — see [hmacSigning].
  */
 @Serializable
 data class HttpRequestConfig(
@@ -17,7 +24,9 @@ data class HttpRequestConfig(
     val method: String = "GET",
     val headers: Map<String, String>? = null,
     val body: String? = null,
-    val timeoutMs: Long = 30000
+    val timeoutMs: Long = 30000,
+    val hmacSigning: HmacSigningConfig? = null,
+    val tokenRefresh: TokenRefreshConfig? = null
 ) {
     val httpMethod: HttpMethod
         get() = HttpMethod.fromString(method)

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/TokenRefreshConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/TokenRefreshConfig.kt
@@ -1,0 +1,66 @@
+package dev.brewkits.kmpworkmanager.workers.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Automatic token refresh on a `401 Unauthorized` response, applied by
+ * [dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker]. Mirrors the Flutter
+ * `native_workmanager` `token_refresh_config.dart` config so a payload shared between the
+ * two scheduling layers parses identically.
+ *
+ * Flow: the original request is sent as configured. If (and only if) it comes back `401`,
+ * the worker issues one request to [refreshUrl], extracts a new token from the JSON
+ * response body via [tokenResponsePath] (dot-notation, e.g. `"auth.access_token"` for
+ * `{"auth":{"access_token":"..."}}`), then retries the **original** request exactly once
+ * with the new token injected into [authHeaderName] as `"$authHeaderPrefix$token"`. There
+ * is no refresh loop: a still-401 retry, a non-2xx refresh response, or a response body
+ * that doesn't contain [tokenResponsePath] all fall through to the original 401 response
+ * rather than retrying again.
+ *
+ * **Security note:** any refresh token or client secret in [refreshBody]/[refreshHeaders]
+ * is persisted as part of the worker's task input (same as an `Authorization` header value
+ * passed via `HttpRequestConfig.headers` today) so it survives process death for retries.
+ * Do not use a secret that must never touch disk.
+ *
+ * @property refreshUrl The HTTP/HTTPS URL to call to obtain a new token.
+ * @property refreshMethod HTTP method for the refresh call. Default `"POST"`.
+ * @property refreshBody Optional raw request body sent to [refreshUrl] (e.g. a JSON
+ *   payload containing a refresh token). Sent with `Content-Type: application/json` when
+ *   non-null.
+ * @property refreshHeaders Optional headers sent with the refresh request (e.g. a client
+ *   ID/secret pair, or a refresh-token cookie).
+ * @property tokenResponsePath Dot-notation path into the refresh response's JSON body
+ *   locating the new token, e.g. `"access_token"` or `"auth.access_token"`. A response
+ *   whose body isn't valid JSON, that doesn't have a JSON primitive value (string or
+ *   number) at this path, or whose value there is blank, is treated as a failed refresh
+ *   (original 401 is returned, not retried).
+ * @property authHeaderName Header the new token is injected into on retry. Default
+ *   `"Authorization"`.
+ * @property authHeaderPrefix Prefix prepended to the token before it's placed in
+ *   [authHeaderName]. Default `"Bearer "` (note the trailing space).
+ */
+@Serializable
+data class TokenRefreshConfig(
+    val refreshUrl: String,
+    val refreshMethod: String = "POST",
+    val refreshBody: String? = null,
+    val refreshHeaders: Map<String, String>? = null,
+    val tokenResponsePath: String = "access_token",
+    val authHeaderName: String = "Authorization",
+    val authHeaderPrefix: String = "Bearer "
+) {
+    init {
+        require(refreshUrl.startsWith("http://") || refreshUrl.startsWith("https://")) {
+            "refreshUrl must start with http:// or https://"
+        }
+        require(refreshMethod.isNotBlank()) {
+            "refreshMethod must not be blank"
+        }
+        require(tokenResponsePath.isNotBlank()) {
+            "tokenResponsePath must not be blank"
+        }
+        require(authHeaderName.isNotBlank()) {
+            "authHeaderName must not be blank"
+        }
+    }
+}


### PR DESCRIPTION
## What

Ships #81: `HttpRequestWorker` gains optional `HmacSigningConfig` (HMAC-SHA256 request signing) and `TokenRefreshConfig` (auto-refresh + one-shot retry on `401`) — Flutter parity Group 2.

## Design

Both are config-scoped, not installed on `HttpClientProvider`'s shared singleton client (which is process-wide across all workers) — so different workers/calls can carry different secrets and refresh endpoints without stepping on each other.

- **HMAC signing**: canonical `METHOD\nURL\nBODY\nTIMESTAMP` → HMAC-SHA256 via Okio's built-in `ByteString.hmacSha256` — no platform-specific crypto/expect-actual needed. Hex-encoded, optional prefix (e.g. `sha256=` for GitHub-webhook style). `signBody`/`includeTimestamp` toggle what's covered.
- **Token refresh**: on `401`, POST a configurable refresh endpoint, extract the new token via a dot-notation JSON path (e.g. `auth.access_token`), retry the original request **exactly once** with the refreshed token. Never loops.

## Security review (folded in before this PR, not left as follow-up)

- `refreshUrl` now passes `SecurityValidator.validateURL()` — checked in `HttpRequestWorker.doWork()` (fails fast, same as the primary `url`) **and** again inside `TokenRefresh.refreshToken()` itself, so any future caller adopting `TokenRefreshConfig` (`HttpSyncWorker`, `HttpUploadWorker`, …) gets the SSRF gate for free instead of needing to remember it — the same drift class `SecureRedirectFollowing.kt`'s own KDoc warns about.
- Real bug caught by the tests: Ktor's `header()` **appends**, not replaces — injecting the refreshed `Authorization` header without removing the stale one first sent both values on retry.
- A GET/DELETE's `config.body` (never written to the wire) is excluded from what gets signed — previously the signature covered bytes the server would never receive.
- A blank token in the refresh response is treated as a failed refresh, not retried with `Authorization: Bearer `.
- Corrected KDoc that incorrectly claimed the HMAC signature covers headers (including a refreshed `Authorization`) — it only covers `METHOD`/`URL`/`BODY`/`TIMESTAMP`.

## Testing

`./gradlew :kmpworker-http:iosSimulatorArm64Test :kmpworker-http:testDebugUnitTest :kmpworker:testDebugUnitTest` — 64/64 on iOS, Android green. New coverage: known-vector HMAC signature test, GET-with-body exclusion, append-vs-replace header regression, token-refresh happy path / still-401 / refresh-endpoint-failure / blank-token / no-config-passthrough, SSRF-blocked `refreshUrl` at both the `doWork()` and `refreshToken()` layers, and `extractByDotPath` edge cases (missing key, non-object mid-path, `null`, array, numeric, empty path).
