### PR TITLE
Combined: iOS dispatcher fix + HTTP worker parity + roadmap update (#80, #83, #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See the [changelog](CHANGELOG.md) for the full history, and the per-version upgr
 
 | Worker | Status | Notes |
 |--------|--------|-------|
-| `HttpRequestWorker` | Stable | One-shot HTTP with configurable method, headers, body. SSRF-validated. |
+| `HttpRequestWorker` | Stable | One-shot HTTP with configurable method, headers, body. SSRF-validated. Optional `HmacSigningConfig` (HMAC-SHA256 request signing, GitHub-webhook-style prefix support) and `TokenRefreshConfig` (auto-refresh + one-shot retry on `401`, dot-notation token extraction from the refresh response). |
 | `HttpDownloadWorker` | Stable (v2.5+) | Resumable download via HTTP `Range`. `<savePath>.partial` survives process kill; a process kill resumes from last byte. Supports SHA-256/SHA-1/SHA-512/MD5 checksum verification and `DuplicatePolicy` (overwrite / skip / rename). |
 | `ParallelHttpDownloadWorker` | Stable | Splits a single file into N (1..16, default 4) HTTP `Range` chunks downloaded concurrently with per-chunk `.partN` resume. Automatic sequential fallback when the server does not advertise `Accept-Ranges: bytes`. Same checksum verification surface as `HttpDownloadWorker`. |
 | `HttpUploadWorker` | ⚠️ Experimental | Streaming multipart upload. No resumable / chunked upload yet (see `ParallelHttpUploadWorker` for multi-file uploads). |

--- a/docs/IOS_BGTASK_LIMITS.md
+++ b/docs/IOS_BGTASK_LIMITS.md
@@ -324,6 +324,45 @@ fired by now. If the user never opens the app, **the task waits indefinitely**.
 
 ---
 
+## 6. Dynamic-task master dispatcher is always a `BGProcessingTask`, never a `BGAppRefreshTask`
+
+### What's actually happening
+
+Dynamic task IDs (not declared in `Info.plist`) are queued internally and
+woken via the single static `kmp_master_dispatcher_task` identifier. That
+dispatcher is **always** submitted as a `BGProcessingTaskRequest` —
+`requiresNetworkConnectivity` is now derived from the pending queue (`true`
+only when *every* pending task requires network; see the fix below), but the
+request *type* itself never becomes the cheaper, more favorably-scheduled
+`BGAppRefreshTaskRequest`, even when every pending task is light. That's
+deliberate: `BGAppRefreshTask`'s hard ~30s ceiling (no extension API) leaves
+no safe margin for the batch executor's per-task timeout (25s) plus wake and
+completion overhead — see
+[docs/ios-dynamic-task-scheduling.md § 5](ios-dynamic-task-scheduling.md#why-not-bgapprefreshtaskrequest-when-the-queue-is-all-light)
+for the full reasoning.
+
+### Library guarantees
+
+- ✅ A task scheduled with a **static ID** declared in `Info.plist` correctly
+  becomes a `BGAppRefreshTaskRequest` when `Constraints.isHeavyTask = false`.
+- ✅ `requiresNetworkConnectivity` on the dynamic-task master dispatcher is
+  `true` when every pending dynamic task requires network, `false` otherwise
+  — so an all-network-dependent queue no longer wakes opportunistically
+  offline just to fail every task and re-queue them.
+- ❌ Dynamic task IDs never get a `BGAppRefreshTaskRequest`, even when every
+  pending task is light — the master dispatcher's request *type* is fixed.
+
+### Workaround
+
+Declare a dedicated static ID for lightweight, network-bound work instead of
+relying on the dynamic-task path — that's the only way to get an actual
+`BGAppRefreshTaskRequest` today. See
+[docs/ios-dynamic-task-scheduling.md § 5](ios-dynamic-task-scheduling.md#5-known-trade-off-master-dispatcher-ignores-per-task-constraints)
+for the full explanation and the tracked follow-up
+([#79](https://github.com/brewkits/kmpworkmanager/issues/79)).
+
+---
+
 ## Summary table
 
 | Limit | Hard ceiling | Library can mitigate? | Workaround |
@@ -333,6 +372,7 @@ fired by now. If the user never opens the app, **the task waits indefinitely**.
 | Headless DI cold-start | ~10 s before budget starts ticking | No | Lazy-init non-BGTask deps; measure cold-start on real devices |
 | No ZIP codec | K/N stdlib gap | Yes (fail-fast default) | Use Swift host for compression, or wait for v2.6 zlib cinterop |
 | Exact alarms need user action | iOS has no "wake at time T and run code" primitive | Partial (catch-up on app open) | Use `UNUserNotification` for user-visible alarms; server-side scheduler for SLA-critical timing |
+| Master dispatcher never becomes `BGAppRefreshTask` | Always `BGProcessingTaskRequest` — 25s per-task timeout leaves no margin under App Refresh's 30s ceiling | No (not safe with current batch executor; network flag alone is fixed) | Use a dedicated static `Info.plist` ID for light tasks |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -550,14 +550,16 @@ bulk photo upload — that must complete even after the user backgrounds the app
   but obviously cannot persist past page reload. Useful for documenting the
   API in a runnable playground.
 
-### 3. Gradle plugin `io.brewkits.kmpworker`
-- 💭 Eliminate the manual `Info.plist` + `AndroidManifest.xml` declarations.
-  The plugin reads `@Worker(bgTaskId = …)` annotations and emits the iOS
-  permitted-identifiers array + the Android `<service android:foregroundServiceType=…>`
-  block. Today these are easy to forget, and the failure mode is silent
-  (tasks "just don't run").
-- 💭 Stretch: synthesize the boot receiver + Hilt module so consumers can drop
-  the plugin and have zero manual wiring.
+### 3. ~~Gradle plugin `io.brewkits.kmpworker`~~ — superseded by #82
+Originally proposed a Gradle plugin generating/validating `Info.plist` +
+`AndroidManifest.xml` declarations from `@Worker` annotations. Superseded:
+iOS already fails loudly via the KSP-generated `BgTaskIdProvider`, and a
+Gradle plugin can't reliably validate the Android side (`@Worker` is
+`SOURCE`-retention; `foregroundServiceType` is a computed `open val`, not a
+literal a plugin could resolve). See
+[#82](https://github.com/brewkits/kmpworkmanager/issues/82) and "Next up"
+above for the shipped replacement (manifest-mismatch diagnostics inside
+`KmpHeavyWorker.doWork()`).
 
 ### 4. Flutter parity — Group 3 built-in workers (long tail)
 - 💭 **Image processing worker** — resize (maxWidth/maxHeight + maintain aspect

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,36 @@ Status legend: ✅ done · 🚧 in progress · ⏳ planned · 💭 idea / unsche
 
 ---
 
+## Next up (post-3.3.1) — the "irreplaceable, even for native-only teams" bar
+
+**Theme:** every milestone through 3.3.1 below made the library more correct or
+more DX-friendly for teams *already* using it across both platforms. These two
+are chosen against a sharper bar: would a team building for **one platform
+only** — no shared-code motive at all — still pick this library over the
+platform's raw API? "Shared code" is worth nothing to that team, so the pitch
+has to come from somewhere else.
+
+- ⏳ **Flutter parity Group 2 — token refresh on 401 + HMAC request signing**
+  ([#81](https://github.com/brewkits/kmpworkmanager/issues/81)). Pitch: WorkManager/BGTaskScheduler give you
+  primitives; this ships a tested implementation of the auth-refresh and
+  request-signing logic most teams under-build (or skip) themselves. Promoted
+  out of the deferred v2.6 #6 slot below — see that entry for the full spec,
+  now superseded by #81 as the tracking issue.
+- ⏳ **Gradle plugin `io.brewkits.kmpworker`** ([#82](https://github.com/brewkits/kmpworkmanager/issues/82)).
+  Pitch: removes a *silent*-failure class (forgetting a worker's
+  `Info.plist`/Manifest declaration → the task just never runs, no error, no
+  warning) that costs native-only and KMP consumers equally. Promoted out of
+  the deferred v3.0 #3 slot below — see that entry for the full spec, now
+  superseded by #82.
+
+Both selected over other v2.6/v3.0 candidates (per-task QoS profiles, threat
+model docs, `ChainExecutor` state machine, `wasmJs` target) specifically
+because those don't clear the bar above — a native-only team can build QoS
+profiles or a state machine themselves without losing much, and docs alone
+don't create lock-in.
+
+---
+
 ## v2.5 — production hardening + Flutter parity (Group 1)
 
 **Theme:** unblock production camera-app adoption. Everything in this milestone

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,23 +22,27 @@ has to come from somewhere else.
   request-signing logic most teams under-build (or skip) themselves. Promoted
   out of the deferred v2.6 #6 slot below — see that entry for the full spec,
   now superseded by #81 as the tracking issue.
-- ⏳ **Android FGS-type runtime check** ([#82](https://github.com/brewkits/kmpworkmanager/issues/82)).
+- ⏳ **Android FGS-type diagnosability** ([#82](https://github.com/brewkits/kmpworkmanager/issues/82)).
   Pitch: on iOS, `@Worker(bgTaskId=…)` + the KSP-generated `BgTaskIdProvider`
   already `require()`-crashes loudly at `KmpWorkManager.initialize()` if a
-  `bgTaskId` is missing from `Info.plist` — Android has no equivalent for a
-  missing `android:foregroundServiceType`. Today the failure only surfaces
-  when a `KmpHeavyWorker` actually calls `setForeground()`, which already
-  catches and logs the resulting exception clearly (see `KmpHeavyWorker.kt`)
-  but only at that point, not at worker registration. #82 originally proposed
-  a Gradle plugin generating/validating manifest entries from `@Worker`
-  annotations at build time; investigation found `@Worker` is
+  `bgTaskId` is missing from `Info.plist` — Android has no equivalent
+  registration-time hook for a missing/mismatched `android:foregroundServiceType`.
+  `KmpHeavyWorker.doWork()` already catches and logs the `setForeground()`
+  exception (see `KmpHeavyWorker.kt`), but the message names only what the
+  worker *declared*, not what the manifest actually has, and on API 29-33
+  a mismatch doesn't throw at all (`ForegroundServiceTypeException` is
+  API 34+) — a real silent-failure window on those OS versions. #82
+  originally proposed a Gradle plugin generating/validating manifest entries
+  from `@Worker` annotations at build time; investigation found `@Worker` is
   `SOURCE`-retention (invisible to a Gradle plugin without a new KSP→Gradle
   pipeline) and `foregroundServiceType` is a computed `open val`, not a
   literal KSP can resolve — so static analysis can't reliably cover this.
-  Revised to an Android-side runtime check (`PackageManager.getServiceInfo()`
-  against the actual merged manifest, compared to the declared type) at
-  `KmpHeavyWorker` construction/init time, moving the check earlier without
-  a new module. See #82 for the corrected scope.
+  Revised to reading the actual merged manifest via
+  `PackageManager.getServiceInfo()` inside `doWork()`: enrich the existing
+  exception log with the manifest's declared type, and add a proactive
+  `Logger.w` on API 29-33 where nothing throws today. No new module,
+  diagnostics-only (never fails a worker on its own). See #82 for the
+  corrected scope.
 
 Both selected over other v2.6/v3.0 candidates (per-task QoS profiles, threat
 model docs, `ChainExecutor` state machine, `wasmJs` target) specifically

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,12 +22,23 @@ has to come from somewhere else.
   request-signing logic most teams under-build (or skip) themselves. Promoted
   out of the deferred v2.6 #6 slot below — see that entry for the full spec,
   now superseded by #81 as the tracking issue.
-- ⏳ **Gradle plugin `io.brewkits.kmpworker`** ([#82](https://github.com/brewkits/kmpworkmanager/issues/82)).
-  Pitch: removes a *silent*-failure class (forgetting a worker's
-  `Info.plist`/Manifest declaration → the task just never runs, no error, no
-  warning) that costs native-only and KMP consumers equally. Promoted out of
-  the deferred v3.0 #3 slot below — see that entry for the full spec, now
-  superseded by #82.
+- ⏳ **Android FGS-type runtime check** ([#82](https://github.com/brewkits/kmpworkmanager/issues/82)).
+  Pitch: on iOS, `@Worker(bgTaskId=…)` + the KSP-generated `BgTaskIdProvider`
+  already `require()`-crashes loudly at `KmpWorkManager.initialize()` if a
+  `bgTaskId` is missing from `Info.plist` — Android has no equivalent for a
+  missing `android:foregroundServiceType`. Today the failure only surfaces
+  when a `KmpHeavyWorker` actually calls `setForeground()`, which already
+  catches and logs the resulting exception clearly (see `KmpHeavyWorker.kt`)
+  but only at that point, not at worker registration. #82 originally proposed
+  a Gradle plugin generating/validating manifest entries from `@Worker`
+  annotations at build time; investigation found `@Worker` is
+  `SOURCE`-retention (invisible to a Gradle plugin without a new KSP→Gradle
+  pipeline) and `foregroundServiceType` is a computed `open val`, not a
+  literal KSP can resolve — so static analysis can't reliably cover this.
+  Revised to an Android-side runtime check (`PackageManager.getServiceInfo()`
+  against the actual merged manifest, compared to the declared type) at
+  `KmpHeavyWorker` construction/init time, moving the check earlier without
+  a new module. See #82 for the corrected scope.
 
 Both selected over other v2.6/v3.0 candidates (per-task QoS profiles, threat
 model docs, `ChainExecutor` state machine, `wasmJs` target) specifically

--- a/docs/ios-dynamic-task-scheduling.md
+++ b/docs/ios-dynamic-task-scheduling.md
@@ -61,3 +61,26 @@ As of version **2.4.3**, KMP WorkManager has implemented **Option 2** (the Libra
 
 This architecture delivers a seamless, unified Developer Experience (DX) across Android and iOS, perfectly aligning with the "Write once, run anywhere" philosophy of Kotlin Multiplatform.
 
+---
+
+## 5. Known Trade-off: Master Dispatcher Ignores Per-Task Constraints
+
+The master dispatcher always submits `kmp_master_dispatcher_task` as a **`BGProcessingTaskRequest`**. As of the fix below, `requiresNetworkConnectivity` is derived from the pending queue; the request *type* itself is always `BGProcessingTaskRequest`, never `BGAppRefreshTaskRequest` — see "Why not `BGAppRefreshTaskRequest`?" below for why that's deliberate, not an oversight.
+
+* **Why unconstrained by default:** a dynamic-task queue is typically mixed (some tasks need network, some don't; some are light, some are heavy). Submitting an unconstrained `BGProcessingTaskRequest` lets non-network tasks run opportunistically even while offline — each worker still checks its own `Constraints.requiresNetwork` at execution time and fails/retries if unmet. Constraining the dispatcher itself would block the *whole* batch on the strictest pending task.
+* **What's fixed:** `NativeTaskScheduler.submitTaskRequest` and `DynamicTaskDispatcher.rescheduleMasterDispatcher` now read `IosFileStorage.getDynamicQueueConstraintSummary()` and set `requiresNetworkConnectivity = true` only when **every** pending dynamic task requires network — so a queue that's entirely network-dependent no longer wakes opportunistically while offline just to fail every task and re-queue them.
+* **This only affects dynamic task IDs.** A task scheduled with a **static ID declared in `Info.plist`** goes through `createBackgroundTaskRequest()` directly and correctly becomes a `BGAppRefreshTaskRequest` when `Constraints.isHeavyTask = false`.
+
+### Why not `BGAppRefreshTaskRequest` when the queue is all-light?
+
+This was the original ask in [discussion #78](https://github.com/brewkits/kmpworkmanager/discussions/78) — use the cheaper, better-scheduled `BGAppRefreshTaskRequest` when every pending task is light. It turns out **not to be safe** with the current batch executor, so it's deliberately not implemented:
+
+* `BGAppRefreshTask` has a hard ceiling of **~30 seconds with no extension API** (see [IOS_BGTASK_LIMITS.md § 1](./IOS_BGTASK_LIMITS.md)).
+* `DynamicTaskDispatcher.executePendingTasks` dequeues and runs tasks in a loop; a single dequeued task may run up to `SingleTaskExecutor.DEFAULT_TIMEOUT_MS` (**25 seconds**) before its own per-task timeout fires.
+* 25s of worker execution plus BGTask wake latency and completion/cleanup overhead leaves no safe margin under a 30s hard ceiling — not even for a *single* queued task, let alone a batch. Unlike a static light task (one task, one `BGAppRefreshTask` window, by construction), the master dispatcher is a **batch** processor sized for `BGProcessingTask`'s multi-minute budget; "every pending task is light" does not mean "the batch fits in 30 seconds."
+* Making this safe would require the dispatcher to know it's running under an App Refresh budget and cap itself to (at most) one task with a much smaller per-task timeout — plus verification on a physical device, since the Simulator doesn't model real `BGTaskScheduler` timing (see the iOS Simulator Fallback warning in `NativeTaskScheduler.kt`).
+
+Tracked as follow-up scope in [brewkits/kmpworkmanager#79](https://github.com/brewkits/kmpworkmanager/issues/79) if it's worth pursuing later.
+
+**Workaround today:** for lightweight, network-bound, latency-sensitive work, declare a dedicated static ID in `BGTaskSchedulerPermittedIdentifiers` instead of relying on the dynamic-task/master-dispatcher path — that's still the only way to get an actual `BGAppRefreshTaskRequest` for iOS background work in this library.
+

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/builtins/HttpRequestWorker.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/builtins/HttpRequestWorker.kt
@@ -9,6 +9,8 @@ import dev.brewkits.kmpworkmanager.workers.config.HttpMethod as WorkerHttpMethod
 import dev.brewkits.kmpworkmanager.workers.config.HttpRequestConfig
 import dev.brewkits.kmpworkmanager.workers.utils.HttpClientProvider
 import dev.brewkits.kmpworkmanager.workers.utils.SecurityValidator
+import dev.brewkits.kmpworkmanager.workers.utils.applyHmacSigning
+import dev.brewkits.kmpworkmanager.workers.utils.executeWithTokenRefresh
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -41,6 +43,16 @@ class HttpRequestWorker(
                 return WorkerResult.Failure("Invalid or unsafe URL")
             }
 
+            // TokenRefreshConfig.refreshUrl is a second outbound destination this worker
+            // calls directly — it must pass the same SSRF gate as the primary URL, not
+            // just the http(s):// prefix check TokenRefreshConfig.init does.
+            config.tokenRefresh?.let { refresh ->
+                if (!SecurityValidator.validateURL(refresh.refreshUrl)) {
+                    Logger.e("HttpRequestWorker", "Invalid or unsafe refresh URL: ${SecurityValidator.sanitizedURL(refresh.refreshUrl)}")
+                    return WorkerResult.Failure("Invalid or unsafe refresh URL")
+                }
+            }
+
             Logger.i("HttpRequestWorker", "Executing ${config.httpMethod} request to ${SecurityValidator.sanitizedURL(config.url)}")
 
             executeRequest(httpClient, config)
@@ -52,29 +64,57 @@ class HttpRequestWorker(
 
     private suspend fun executeRequest(client: HttpClient, config: HttpRequestConfig): WorkerResult {
         return try {
-            val response: HttpResponse = client.request(config.url) {
-                method = when (config.httpMethod) {
-                    WorkerHttpMethod.GET -> HttpMethod.Get
-                    WorkerHttpMethod.POST -> HttpMethod.Post
-                    WorkerHttpMethod.PUT -> HttpMethod.Put
-                    WorkerHttpMethod.DELETE -> HttpMethod.Delete
-                    WorkerHttpMethod.PATCH -> HttpMethod.Patch
-                }
+            val response: HttpResponse = executeWithTokenRefresh(client, config.tokenRefresh) { newToken ->
+                client.request(config.url) {
+                    method = when (config.httpMethod) {
+                        WorkerHttpMethod.GET -> HttpMethod.Get
+                        WorkerHttpMethod.POST -> HttpMethod.Post
+                        WorkerHttpMethod.PUT -> HttpMethod.Put
+                        WorkerHttpMethod.DELETE -> HttpMethod.Delete
+                        WorkerHttpMethod.PATCH -> HttpMethod.Patch
+                    }
 
-                timeout {
-                    requestTimeoutMillis = config.timeoutMs
-                    connectTimeoutMillis = config.timeoutMs
-                    socketTimeoutMillis = config.timeoutMs
-                }
+                    timeout {
+                        requestTimeoutMillis = config.timeoutMs
+                        connectTimeoutMillis = config.timeoutMs
+                        socketTimeoutMillis = config.timeoutMs
+                    }
 
-                SecurityValidator.sanitizeHeaders(config.headers)?.forEach { (key, value) ->
-                    header(key, value)
-                }
+                    SecurityValidator.sanitizeHeaders(config.headers)?.forEach { (key, value) ->
+                        header(key, value)
+                    }
 
-                // Set body for POST/PUT/PATCH
-                if (config.body != null && config.httpMethod in setOf(WorkerHttpMethod.PUT, WorkerHttpMethod.PATCH, WorkerHttpMethod.POST)) {
-                    setBody(config.body)
-                    contentType(ContentType.Application.Json)
+                    // Set body for POST/PUT/PATCH. Body-bearing methods only — a body sent
+                    // in the config for GET/DELETE is never written to the wire, and must
+                    // therefore also be excluded from what gets signed below.
+                    val sendsBody = config.httpMethod in setOf(WorkerHttpMethod.PUT, WorkerHttpMethod.PATCH, WorkerHttpMethod.POST)
+                    val bodyOnWire = config.body.takeIf { sendsBody }
+                    if (bodyOnWire != null) {
+                        setBody(bodyOnWire)
+                        contentType(ContentType.Application.Json)
+                    }
+
+                    // A retried request (newToken != null) overrides whatever Authorization
+                    // config.headers set above — the refreshed token is what must be sent.
+                    // `header()` APPENDS (Ktor's HeadersBuilder), so the stale value set
+                    // above must be removed first or the request would carry both.
+                    val tokenRefresh = config.tokenRefresh
+                    if (newToken != null && tokenRefresh != null) {
+                        headers.remove(tokenRefresh.authHeaderName)
+                        header(tokenRefresh.authHeaderName, "${tokenRefresh.authHeaderPrefix}$newToken")
+                    }
+
+                    // NOTE: computeHmacSignature signs METHOD/URL/BODY/TIMESTAMP only — it
+                    // does NOT cover headers, so a refreshed Authorization header above is
+                    // NOT part of what's signed. What DOES differ between the original and
+                    // retried attempt is the timestamp (recomputed per call), so the two
+                    // signatures differ even though the covered fields are otherwise the same.
+                    // bodyOnWire (not config.body) — must match exactly what setBody sent,
+                    // so a GET/DELETE with a config.body that's never written to the wire
+                    // doesn't sign bytes the server will never see.
+                    config.hmacSigning?.let { signingConfig ->
+                        applyHmacSigning(config.httpMethod.name, config.url, bodyOnWire, signingConfig)
+                    }
                 }
             }
 

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigning.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigning.kt
@@ -1,0 +1,64 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.utils.currentTimeMillis
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import okio.ByteString.Companion.encodeUtf8
+
+/**
+ * Computes the HMAC-SHA256 signature for the canonical string `METHOD\nURL\nBODY\nTIMESTAMP`.
+ *
+ * Pure function — no I/O, no Ktor dependency beyond the config type — so it's testable
+ * without a live or mocked HTTP client. [HmacSigningConfig.signBody]/[HmacSigningConfig.includeTimestamp]
+ * control whether [body]/[timestamp] contribute to the canonical string (an omitted
+ * component is an empty line, not a removed one, so the line count — and therefore the
+ * signature — always reflects which components are enabled).
+ *
+ * Uses Okio's built-in `ByteString.hmacSha256` (no platform-specific crypto needed —
+ * Okio implements HMAC-SHA256 natively on every KMP target this library supports).
+ *
+ * @return the hex-encoded signature, prefixed with [HmacSigningConfig.signaturePrefix] if set.
+ */
+internal fun computeHmacSignature(
+    method: String,
+    url: String,
+    body: String?,
+    timestamp: String?,
+    config: HmacSigningConfig
+): String {
+    val canonical = buildString {
+        append(method.uppercase())
+        append('\n')
+        append(url)
+        append('\n')
+        append(if (config.signBody) body.orEmpty() else "")
+        append('\n')
+        append(timestamp.orEmpty())
+    }
+    val digest = canonical.encodeUtf8()
+        .hmacSha256(config.secretKey.encodeUtf8())
+        .hex()
+    return config.signaturePrefix?.let { it + digest } ?: digest
+}
+
+/**
+ * Applies [HmacSigningConfig] to this request builder: computes the signature (and, when
+ * [HmacSigningConfig.includeTimestamp] is set, the timestamp used in it) and adds the
+ * corresponding header(s). Call this **after** every other header/body mutation on
+ * [this] builder — the signature must cover the final outgoing request, not an
+ * intermediate state.
+ */
+internal fun HttpRequestBuilder.applyHmacSigning(
+    method: String,
+    url: String,
+    body: String?,
+    config: HmacSigningConfig
+) {
+    val timestamp = if (config.includeTimestamp) currentTimeMillis().toString() else null
+    val signature = computeHmacSignature(method, url, body, timestamp, config)
+    header(config.headerName, signature)
+    if (timestamp != null) {
+        header(config.timestampHeaderName, timestamp)
+    }
+}

--- a/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefresh.kt
+++ b/kmpworker-http/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefresh.kt
@@ -1,0 +1,105 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.utils.Logger
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val TAG = "TokenRefresh"
+
+/**
+ * Executes [request] (the original request); if it comes back `401` and [config] is
+ * non-null, refreshes the token via [config] and retries [request] **exactly once** with
+ * the new token. Never loops: a still-401 retry response, a failed/non-2xx refresh call,
+ * or a refresh response body that doesn't contain [TokenRefreshConfig.tokenResponsePath]
+ * are all returned/passed through as the final result rather than retrying again.
+ *
+ * @param request Executes and returns the original request. Receives the new token (or
+ *   `null` on the first call) so the caller can inject it into the appropriate header —
+ *   this function does not assume where in the request the auth header lives beyond what
+ *   [TokenRefreshConfig.authHeaderName] says, since the caller may also need to re-apply
+ *   HMAC signing over the refreshed header.
+ */
+internal suspend fun executeWithTokenRefresh(
+    client: HttpClient,
+    config: TokenRefreshConfig?,
+    request: suspend (newToken: String?) -> HttpResponse
+): HttpResponse {
+    val first = request(null)
+    if (config == null || first.status != HttpStatusCode.Unauthorized) return first
+
+    val newToken = refreshToken(client, config)
+    if (newToken == null) {
+        Logger.w(TAG, "Token refresh failed or returned no usable token — returning original 401")
+        return first
+    }
+
+    Logger.i(TAG, "Token refreshed — retrying original request once")
+    return request(newToken)
+}
+
+private suspend fun refreshToken(client: HttpClient, config: TokenRefreshConfig): String? {
+    // Belt-and-suspenders SSRF gate: HttpRequestWorker validates refreshUrl in doWork()
+    // before this ever runs, but that gate lives in the caller, not here. Checking again
+    // makes this function safe by construction for any future caller (HttpSyncWorker,
+    // HttpUploadWorker, …) that adopts TokenRefreshConfig without remembering to
+    // replicate the same check — the exact drift class fixed in installSecureRedirectFollowing().
+    if (!SecurityValidator.validateURL(config.refreshUrl)) {
+        Logger.e(TAG, "Refusing to call unsafe refresh URL: ${SecurityValidator.sanitizedURL(config.refreshUrl)}")
+        return null
+    }
+    return try {
+        val response = client.request(config.refreshUrl) {
+            method = HttpMethod.parse(config.refreshMethod)
+            config.refreshHeaders?.forEach { (key, value) -> header(key, value) }
+            if (config.refreshBody != null) {
+                setBody(config.refreshBody)
+                contentType(ContentType.Application.Json)
+            }
+        }
+        if (response.status.value !in 200..299) {
+            Logger.w(TAG, "Refresh endpoint returned ${response.status.value} — not retrying original request")
+            return null
+        }
+        val json = Json.parseToJsonElement(response.bodyAsText())
+        // Blank counts as "no usable token" — an empty access_token would otherwise send
+        // "Authorization: Bearer " on retry, a request the server will reject anyway but
+        // that masks the real failure (a malformed/incomplete refresh response) behind a
+        // second, misleading 401.
+        extractByDotPath(json, config.tokenResponsePath)?.takeUnless { it.isBlank() }
+    } catch (e: Exception) {
+        Logger.e(TAG, "Token refresh call to ${SecurityValidator.sanitizedURL(config.refreshUrl)} failed", e)
+        null
+    }
+}
+
+/**
+ * Navigates [root] through [path]'s dot-separated keys (e.g. `"auth.access_token"` into
+ * `{"auth":{"access_token":"..."}}`) and returns the string content of the value found
+ * there, or `null` if any segment is missing, not an object, or the final value isn't a
+ * JSON string/primitive.
+ */
+internal fun extractByDotPath(root: JsonElement, path: String): String? {
+    var current: JsonElement = root
+    for (key in path.split('.')) {
+        val obj = current as? JsonObject ?: return null
+        current = obj[key] ?: return null
+    }
+    val primitive = current as? JsonPrimitive ?: return null
+    return primitive.takeUnless { it == kotlinx.serialization.json.JsonNull }?.let {
+        runCatching { it.jsonPrimitive.content }.getOrNull()
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/HttpRequestSigningAndTokenRefreshTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/HttpRequestSigningAndTokenRefreshTest.kt
@@ -1,0 +1,265 @@
+package dev.brewkits.kmpworkmanager.workers
+
+import dev.brewkits.kmpworkmanager.background.domain.WorkerEnvironment
+import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
+import dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import dev.brewkits.kmpworkmanager.workers.config.HttpRequestConfig
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import dev.brewkits.kmpworkmanager.workers.utils.HttpWorkerJson
+import dev.brewkits.kmpworkmanager.workers.utils.computeHmacSignature
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for [HttpRequestWorker]'s HMAC signing ([HmacSigningConfig]) and
+ * token-refresh-on-401 ([TokenRefreshConfig]) integration — issues #78/#81.
+ */
+class HttpRequestSigningAndTokenRefreshTest {
+
+    private fun mockClient(engine: MockEngine) = HttpClient(engine) { install(HttpTimeout) }
+
+    // ==================== HMAC signing ====================
+
+    @Test
+    fun hmacSigning_addsSignatureAndTimestampHeaders_matchingIndependentComputation() = runTest {
+        var observedSignature: String? = null
+        var observedTimestamp: String? = null
+        val mock = MockEngine { request ->
+            observedSignature = request.headers["X-Signature"]
+            observedTimestamp = request.headers["X-Timestamp"]
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef")
+        val config = HttpRequestConfig(url = "https://api.example.com/things", method = "POST", body = "payload", hmacSigning = signing)
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Success, "expected Success, got: $result")
+        assertNotNull(observedSignature, "X-Signature header must be present")
+        assertNotNull(observedTimestamp, "X-Timestamp header must be present when includeTimestamp is true (default)")
+        val expected = computeHmacSignature("POST", config.url, config.body, observedTimestamp, signing)
+        assertEquals(expected, observedSignature, "signature must match independently recomputing over the same inputs")
+    }
+
+    @Test
+    fun hmacSigning_includeTimestampFalse_omitsTimestampHeader() = runTest {
+        var sawTimestampHeader = false
+        val mock = MockEngine { request ->
+            sawTimestampHeader = request.headers.contains("X-Timestamp")
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef", includeTimestamp = false)
+        val config = HttpRequestConfig(url = "https://api.example.com/things", hmacSigning = signing)
+
+        worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(!sawTimestampHeader)
+    }
+
+    // ==================== Token refresh ====================
+
+    @Test
+    fun tokenRefresh_on401_refreshesAndRetriesOnce_thenSucceeds() = runTest {
+        var callCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> {
+                    callCount++
+                    respond(
+                        content = """{"auth":{"access_token":"new-token-123"}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.headers[HttpHeaders.Authorization] == "Bearer new-token-123" -> {
+                    callCount++
+                    respond(content = "protected data", status = HttpStatusCode.OK)
+                }
+                else -> {
+                    callCount++
+                    respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val refresh = TokenRefreshConfig(
+            refreshUrl = "https://api.example.com/refresh",
+            tokenResponsePath = "auth.access_token"
+        )
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            headers = mapOf("Authorization" to "Bearer stale-token"),
+            tokenRefresh = refresh
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Success, "expected Success after refresh+retry, got: $result")
+        assertEquals(3, callCount, "expected exactly 3 calls: original 401, refresh, retried request")
+    }
+
+    @Test
+    fun tokenRefresh_stillUnauthorizedAfterRetry_doesNotLoop() = runTest {
+        var protectedCallCount = 0
+        var refreshCallCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> {
+                    refreshCallCount++
+                    respond(
+                        content = """{"access_token":"new-token"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> {
+                    protectedCallCount++
+                    respond(content = "still unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure, "still-401 after retry must surface as Failure, got: $result")
+        assertEquals(1, refreshCallCount, "refresh must be attempted exactly once — no retry loop")
+        assertEquals(2, protectedCallCount, "protected endpoint hit exactly twice: original + one retry")
+    }
+
+    @Test
+    fun tokenRefresh_refreshEndpointFails_returnsOriginal401_withoutRetrying() = runTest {
+        var protectedCallCount = 0
+        val mock = MockEngine { request ->
+            if (request.url.encodedPath == "/refresh") {
+                respond(content = "server error", status = HttpStatusCode.InternalServerError)
+            } else {
+                protectedCallCount++
+                respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, protectedCallCount, "must not retry the original request when refresh itself failed")
+    }
+
+    @Test
+    fun noTokenRefreshConfig_401PassesThroughUnchanged_noRefreshCallAttempted() = runTest {
+        var callCount = 0
+        val mock = MockEngine { _ ->
+            callCount++
+            respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(url = "https://api.example.com/protected") // tokenRefresh = null
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, callCount, "with no tokenRefresh config, exactly one call — no refresh attempted")
+    }
+
+    @Test
+    fun tokenRefresh_ssrfBlockedRefreshUrl_failsBeforeAnyRequest() = runTest {
+        var callCount = 0
+        // MockEngine that fails the test if invoked — proves the SSRF gate on refreshUrl
+        // rejects the config before ANY network call, primary request included.
+        val mock = MockEngine { _ ->
+            callCount++
+            respond(content = "should not be called", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            // Cloud-metadata link-local address — the same one BuiltinWorkersTest uses to
+            // pin SecurityValidator's SSRF blocklist for the primary URL.
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "http://169.254.169.254/latest/meta-data/")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals("Invalid or unsafe refresh URL", result.message)
+        assertEquals(0, callCount, "no request — neither primary nor refresh — may be issued when refreshUrl is SSRF-blocked")
+    }
+
+    @Test
+    fun tokenRefresh_blankToken_treatedAsFailedRefresh_doesNotRetryWithEmptyBearer() = runTest {
+        var protectedCallCount = 0
+        val mock = MockEngine { request ->
+            when {
+                request.url.encodedPath == "/refresh" -> respond(
+                    content = """{"access_token":""}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+                else -> {
+                    protectedCallCount++
+                    assertTrue(
+                        request.headers[HttpHeaders.Authorization] != "Bearer ",
+                        "must never send an empty-token Authorization header"
+                    )
+                    respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+            }
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val config = HttpRequestConfig(
+            url = "https://api.example.com/protected",
+            tokenRefresh = TokenRefreshConfig(refreshUrl = "https://api.example.com/refresh")
+        )
+
+        val result = worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        assertTrue(result is WorkerResult.Failure)
+        assertEquals(1, protectedCallCount, "a blank refreshed token must not trigger a retry")
+    }
+
+    // ==================== HMAC signing does not cover the request body on GET ====================
+
+    @Test
+    fun hmacSigning_getRequestWithConfigBody_signatureExcludesBody_sinceBodyIsNeverSent() = runTest {
+        var observedSignature: String? = null
+        var observedTimestamp: String? = null
+        val mock = MockEngine { request ->
+            observedSignature = request.headers["X-Signature"]
+            observedTimestamp = request.headers["X-Timestamp"]
+            respond(content = "ok", status = HttpStatusCode.OK)
+        }
+        val worker = HttpRequestWorker(mockClient(mock))
+        val signing = HmacSigningConfig(secretKey = "0123456789abcdef")
+        // GET with a body: HttpRequestWorker never calls setBody for GET, so the signature
+        // must be computed as if body were null — not over this (unsent) value.
+        val config = HttpRequestConfig(url = "https://api.example.com/things", method = "GET", body = "never-sent", hmacSigning = signing)
+
+        worker.doWork(HttpWorkerJson.encodeToString(config), WorkerEnvironment(null) { false })
+
+        val expected = computeHmacSignature("GET", config.url, null, observedTimestamp, signing)
+        assertEquals(expected, observedSignature)
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigningTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/HmacRequestSigningTest.kt
@@ -1,0 +1,88 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.workers.config.HmacSigningConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [computeHmacSignature] — pure-function coverage, no HTTP client involved.
+ *
+ * The known-vector test pins the exact canonical-string format (`METHOD\nURL\nBODY\nTIMESTAMP`)
+ * against an independently computed HMAC-SHA256 digest, so a future refactor that
+ * accidentally reorders or drops a line breaks loudly instead of just changing the output
+ * silently (both sides of a client/server pair must agree on the exact canonical format).
+ */
+class HmacRequestSigningTest {
+
+    private val secret = "0123456789abcdef" // exactly 16 chars — the minimum allowed
+
+    // HMAC-SHA256("0123456789abcdef", "POST\nhttps://api.example.com/upload\nhello\n1700000000000")
+    // computed independently via Python's hmac/hashlib for cross-check.
+    private val knownVectorSignature = "72cadd50011f98595398c334c9543dc53380f430ec5355a7823a66c2ef46d9fd".let {
+        // Guard against a typo in the constant above breaking every test with a confusing
+        // "expected 64 chars" failure far from the actual assertion.
+        require(it.length == 64) { "test constant must be a 64-char SHA-256 hex digest" }
+        it
+    }
+
+    @Test
+    fun knownVector_matchesIndependentlyComputedDigest() {
+        val config = HmacSigningConfig(secretKey = secret)
+
+        val signature = computeHmacSignature(
+            method = "post", // lowercase on purpose — canonical form uppercases it
+            url = "https://api.example.com/upload",
+            body = "hello",
+            timestamp = "1700000000000",
+            config = config
+        )
+
+        assertEquals(knownVectorSignature, signature)
+    }
+
+    @Test
+    fun signaturePrefix_isPrependedToTheHexDigest() {
+        val config = HmacSigningConfig(secretKey = secret, signaturePrefix = "sha256=")
+
+        val signature = computeHmacSignature("POST", "https://x", "body", "123", config)
+
+        assertTrue(signature.startsWith("sha256="))
+        assertEquals("sha256=" + computeHmacSignature("POST", "https://x", "body", "123", config.copy(signaturePrefix = null)), signature)
+    }
+
+    @Test
+    fun signBodyFalse_ignoresBodyDifferences() {
+        val config = HmacSigningConfig(secretKey = secret, signBody = false)
+
+        val withBodyA = computeHmacSignature("POST", "https://x", "body-a", "123", config)
+        val withBodyB = computeHmacSignature("POST", "https://x", "body-b", "123", config)
+
+        assertEquals(withBodyA, withBodyB, "signBody=false must make the signature independent of the body content")
+    }
+
+    @Test
+    fun signBodyTrue_differsAcrossBodies() {
+        val config = HmacSigningConfig(secretKey = secret, signBody = true)
+
+        val withBodyA = computeHmacSignature("POST", "https://x", "body-a", "123", config)
+        val withBodyB = computeHmacSignature("POST", "https://x", "body-b", "123", config)
+
+        assertNotEquals(withBodyA, withBodyB)
+    }
+
+    @Test
+    fun differentSecretKeys_produceDifferentSignatures() {
+        val a = computeHmacSignature("POST", "https://x", "body", "123", HmacSigningConfig(secretKey = "aaaaaaaaaaaaaaaa"))
+        val b = computeHmacSignature("POST", "https://x", "body", "123", HmacSigningConfig(secretKey = "bbbbbbbbbbbbbbbb"))
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun secretKeyUnder16Chars_isRejectedAtConstruction() {
+        val error = kotlin.runCatching { HmacSigningConfig(secretKey = "short") }.exceptionOrNull()
+        assertTrue(error is IllegalArgumentException, "expected construction to fail, got: $error")
+    }
+}

--- a/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefreshTest.kt
+++ b/kmpworker-http/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/workers/utils/TokenRefreshTest.kt
@@ -1,0 +1,114 @@
+package dev.brewkits.kmpworkmanager.workers.utils
+
+import dev.brewkits.kmpworkmanager.workers.config.TokenRefreshConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pure-function coverage for [extractByDotPath] — no HTTP client involved.
+ */
+class TokenRefreshTest {
+
+    private fun json(text: String) = Json.parseToJsonElement(text)
+
+    @Test
+    fun topLevelKey_extractsDirectly() {
+        assertEquals("abc123", extractByDotPath(json("""{"access_token":"abc123"}"""), "access_token"))
+    }
+
+    @Test
+    fun nestedKey_navigatesThroughDots() {
+        assertEquals("abc123", extractByDotPath(json("""{"auth":{"access_token":"abc123"}}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun deeplyNestedKey_navigatesThroughMultipleLevels() {
+        val doc = json("""{"a":{"b":{"c":{"d":"deep-value"}}}}""")
+        assertEquals("deep-value", extractByDotPath(doc, "a.b.c.d"))
+    }
+
+    @Test
+    fun missingKey_atTopLevel_returnsNull() {
+        assertNull(extractByDotPath(json("""{"other":"x"}"""), "access_token"))
+    }
+
+    @Test
+    fun missingKey_partwayThroughPath_returnsNull() {
+        assertNull(extractByDotPath(json("""{"auth":{"other":"x"}}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun nonObjectMidPath_returnsNull_ratherThanThrowing() {
+        // "auth" is a string, not an object — trying to navigate ".access_token" into it
+        // must fail gracefully, not throw a ClassCastException from a malformed/unexpected
+        // refresh response shape.
+        assertNull(extractByDotPath(json("""{"auth":"not-an-object"}"""), "auth.access_token"))
+    }
+
+    @Test
+    fun jsonNullValue_returnsNull() {
+        assertNull(extractByDotPath(json("""{"access_token":null}"""), "access_token"))
+    }
+
+    @Test
+    fun numericValue_returnsItsStringContent() {
+        // Some backends return a numeric token/ID; JsonPrimitive.content still yields its
+        // textual form, so this is treated as usable rather than silently failing.
+        assertEquals("12345", extractByDotPath(json("""{"access_token":12345}"""), "access_token"))
+    }
+
+    @Test
+    fun arrayValue_returnsNull_notAToStringDump() {
+        assertNull(extractByDotPath(json("""{"access_token":["a","b"]}"""), "access_token"))
+    }
+
+    @Test
+    fun emptyPath_returnsNull() {
+        assertNull(extractByDotPath(json("""{"access_token":"abc"}"""), ""))
+    }
+
+    // ==================== executeWithTokenRefresh: SSRF gate is inside refreshToken(), ====================
+    // ==================== not only in HttpRequestWorker.doWork() ====================
+
+    /**
+     * Calls [executeWithTokenRefresh] directly — bypassing `HttpRequestWorker.doWork()`'s
+     * own `validateURL(refreshUrl)` check entirely — to prove the gate inside
+     * `refreshToken()` itself rejects an SSRF-blocked refresh URL. A test that only went
+     * through `HttpRequestWorker` would pass on the location of the check, not the check;
+     * this pins the check at the layer any future `TokenRefreshConfig` caller shares.
+     */
+    @Test
+    fun executeWithTokenRefresh_ssrfBlockedRefreshUrl_neverCallsRefreshEndpoint() = runTest {
+        var refreshEndpointCallCount = 0
+        val mock = MockEngine { request ->
+            if (request.url.host == "169.254.169.254") {
+                refreshEndpointCallCount++
+                respond(content = "should never be reached", status = HttpStatusCode.OK)
+            } else {
+                respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+            }
+        }
+        val client = HttpClient(mock) { install(HttpTimeout) }
+        val config = TokenRefreshConfig(refreshUrl = "http://169.254.169.254/latest/meta-data/")
+
+        var originalRequestCallCount = 0
+        val response: HttpResponse = executeWithTokenRefresh(client, config) {
+            originalRequestCallCount++
+            client.request("https://api.example.com/protected") { }
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status, "original 401 must be returned when refresh is blocked")
+        assertEquals(0, refreshEndpointCallCount, "refreshToken() must reject the SSRF-blocked URL before any HTTP call")
+        assertEquals(1, originalRequestCallCount, "no retry — refresh never produced a token")
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HmacSigningConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HmacSigningConfig.kt
@@ -1,0 +1,59 @@
+package dev.brewkits.kmpworkmanager.workers.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * HMAC-SHA256 request signing, applied by [dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker]
+ * before a request is sent. Mirrors the Flutter `native_workmanager` `request_signing.dart`
+ * config so a payload shared between the two scheduling layers parses identically.
+ *
+ * The canonical string signed is:
+ * ```
+ * METHOD\nURL\nBODY\nTIMESTAMP
+ * ```
+ * where `BODY` is empty when [signBody] is `false`, and `TIMESTAMP` is empty when
+ * [includeTimestamp] is `false`. The signature is HMAC-SHA256([secretKey], canonical),
+ * hex-encoded, and sent in the [headerName] header (optionally prefixed by
+ * [signaturePrefix] — e.g. `"sha256="` for GitHub-webhook-style signatures).
+ *
+ * **Security note:** [secretKey] is persisted as part of the worker's task input (same as
+ * any `Authorization` header value passed via `HttpRequestConfig.headers` today) so it
+ * survives process death for retries. Do not use a key that must never touch disk.
+ *
+ * @property secretKey The HMAC signing key. Minimum 16 characters — a shorter key is
+ *   rejected at construction time rather than producing a weak, easily brute-forced signature.
+ * @property headerName Header the computed signature is sent in. Default `"X-Signature"`.
+ * @property signaturePrefix Optional prefix prepended to the hex signature before it's
+ *   placed in [headerName] — e.g. `"sha256="` to match GitHub webhook signature format.
+ *   `null` (default) sends the raw hex digest with no prefix.
+ * @property signBody When `true` (default), the request body is included in the canonical
+ *   string. Set `false` for GET/DELETE requests with no body, or when the body is streamed
+ *   and unavailable at signing time.
+ * @property includeTimestamp When `true` (default), a millisecond epoch timestamp is
+ *   included in the canonical string and also sent in [timestampHeaderName], letting the
+ *   receiving server reject stale/replayed requests. Set `false` for servers whose
+ *   canonical format has no timestamp component.
+ * @property timestampHeaderName Header the timestamp is sent in when [includeTimestamp] is
+ *   `true`. Default `"X-Timestamp"`.
+ */
+@Serializable
+data class HmacSigningConfig(
+    val secretKey: String,
+    val headerName: String = "X-Signature",
+    val signaturePrefix: String? = null,
+    val signBody: Boolean = true,
+    val includeTimestamp: Boolean = true,
+    val timestampHeaderName: String = "X-Timestamp"
+) {
+    init {
+        require(secretKey.length >= 16) {
+            "secretKey must be at least 16 characters, got ${secretKey.length}"
+        }
+        require(headerName.isNotBlank()) {
+            "headerName must not be blank"
+        }
+        require(timestampHeaderName.isNotBlank()) {
+            "timestampHeaderName must not be blank"
+        }
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HttpRequestConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/HttpRequestConfig.kt
@@ -10,6 +10,13 @@ import kotlinx.serialization.Serializable
  * @property headers Optional HTTP headers
  * @property body Optional request body (for POST, PUT, PATCH)
  * @property timeoutMs Request timeout in milliseconds (default: 30000ms = 30s)
+ * @property hmacSigning Optional HMAC-SHA256 request signing — see [HmacSigningConfig]. The
+ *   signature covers `METHOD`/`URL`/`BODY`/`TIMESTAMP` only, **not headers** — it does not
+ *   cover [headers] or a refreshed `Authorization` header from [tokenRefresh].
+ * @property tokenRefresh Optional automatic token refresh on `401` — see
+ *   [TokenRefreshConfig]. When [hmacSigning] is also set, the retried request is re-signed
+ *   with a fresh timestamp (so its signature differs from the original attempt's), but the
+ *   signature still does not cover the refreshed `Authorization` header — see [hmacSigning].
  */
 @Serializable
 data class HttpRequestConfig(
@@ -17,7 +24,9 @@ data class HttpRequestConfig(
     val method: String = "GET",
     val headers: Map<String, String>? = null,
     val body: String? = null,
-    val timeoutMs: Long = 30000
+    val timeoutMs: Long = 30000,
+    val hmacSigning: HmacSigningConfig? = null,
+    val tokenRefresh: TokenRefreshConfig? = null
 ) {
     val httpMethod: HttpMethod
         get() = HttpMethod.fromString(method)

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/TokenRefreshConfig.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/workers/config/TokenRefreshConfig.kt
@@ -1,0 +1,66 @@
+package dev.brewkits.kmpworkmanager.workers.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Automatic token refresh on a `401 Unauthorized` response, applied by
+ * [dev.brewkits.kmpworkmanager.workers.builtins.HttpRequestWorker]. Mirrors the Flutter
+ * `native_workmanager` `token_refresh_config.dart` config so a payload shared between the
+ * two scheduling layers parses identically.
+ *
+ * Flow: the original request is sent as configured. If (and only if) it comes back `401`,
+ * the worker issues one request to [refreshUrl], extracts a new token from the JSON
+ * response body via [tokenResponsePath] (dot-notation, e.g. `"auth.access_token"` for
+ * `{"auth":{"access_token":"..."}}`), then retries the **original** request exactly once
+ * with the new token injected into [authHeaderName] as `"$authHeaderPrefix$token"`. There
+ * is no refresh loop: a still-401 retry, a non-2xx refresh response, or a response body
+ * that doesn't contain [tokenResponsePath] all fall through to the original 401 response
+ * rather than retrying again.
+ *
+ * **Security note:** any refresh token or client secret in [refreshBody]/[refreshHeaders]
+ * is persisted as part of the worker's task input (same as an `Authorization` header value
+ * passed via `HttpRequestConfig.headers` today) so it survives process death for retries.
+ * Do not use a secret that must never touch disk.
+ *
+ * @property refreshUrl The HTTP/HTTPS URL to call to obtain a new token.
+ * @property refreshMethod HTTP method for the refresh call. Default `"POST"`.
+ * @property refreshBody Optional raw request body sent to [refreshUrl] (e.g. a JSON
+ *   payload containing a refresh token). Sent with `Content-Type: application/json` when
+ *   non-null.
+ * @property refreshHeaders Optional headers sent with the refresh request (e.g. a client
+ *   ID/secret pair, or a refresh-token cookie).
+ * @property tokenResponsePath Dot-notation path into the refresh response's JSON body
+ *   locating the new token, e.g. `"access_token"` or `"auth.access_token"`. A response
+ *   whose body isn't valid JSON, that doesn't have a JSON primitive value (string or
+ *   number) at this path, or whose value there is blank, is treated as a failed refresh
+ *   (original 401 is returned, not retried).
+ * @property authHeaderName Header the new token is injected into on retry. Default
+ *   `"Authorization"`.
+ * @property authHeaderPrefix Prefix prepended to the token before it's placed in
+ *   [authHeaderName]. Default `"Bearer "` (note the trailing space).
+ */
+@Serializable
+data class TokenRefreshConfig(
+    val refreshUrl: String,
+    val refreshMethod: String = "POST",
+    val refreshBody: String? = null,
+    val refreshHeaders: Map<String, String>? = null,
+    val tokenResponsePath: String = "access_token",
+    val authHeaderName: String = "Authorization",
+    val authHeaderPrefix: String = "Bearer "
+) {
+    init {
+        require(refreshUrl.startsWith("http://") || refreshUrl.startsWith("https://")) {
+            "refreshUrl must start with http:// or https://"
+        }
+        require(refreshMethod.isNotBlank()) {
+            "refreshMethod must not be blank"
+        }
+        require(tokenResponsePath.isNotBlank()) {
+            "tokenResponsePath must not be blank"
+        }
+        require(authHeaderName.isNotBlank()) {
+            "authHeaderName must not be blank"
+        }
+    }
+}

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
@@ -274,17 +274,29 @@ public class DynamicTaskDispatcher(
 
     private fun currentTimeMs(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()
 
-    private fun rescheduleMasterDispatcher() {
+    private suspend fun rescheduleMasterDispatcher() {
         if (NSBundle.mainBundle.bundleIdentifier == null) return
+
+        // Derive requiresNetworkConnectivity from what's actually still pending, instead of
+        // always requesting unconstrained. See docs/ios-dynamic-task-scheduling.md § 5.
+        //
+        // The dispatcher stays a BGProcessingTaskRequest here (never BGAppRefreshTaskRequest)
+        // even when every pending task is light — see the NOTE in
+        // NativeTaskScheduler.submitTaskRequest's dynamic-task branch for why that's not safe
+        // yet with the current batch executor's per-task timeout budget.
+        val summary = fileStorage.getDynamicQueueConstraintSummary()
+        val requiresNetwork = summary.allRequireNetwork
 
         memScoped {
             val errorPtr = alloc<ObjCObjectVar<NSError?>>()
-            val request = BGProcessingTaskRequest("kmp_master_dispatcher_task")
-            request.earliestBeginDate = NSDate()
-            // Individual task network constraints are checked by each worker.
-            // false here allows non-network tasks to run opportunistically even without
-            // connectivity; workers that need network return Failure and remain in the queue.
-            request.requiresNetworkConnectivity = false
+            val request = BGProcessingTaskRequest("kmp_master_dispatcher_task").apply {
+                earliestBeginDate = NSDate()
+                // Individual task network constraints are checked by each worker.
+                // Only require network here when EVERY pending task needs it — otherwise
+                // false lets non-network tasks run opportunistically even without
+                // connectivity; workers that need network return Failure and remain queued.
+                requiresNetworkConnectivity = requiresNetwork
+            }
 
             val ok = BGTaskScheduler.sharedScheduler.submitTaskRequest(request, errorPtr.ptr)
             if (!ok) {

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -43,6 +43,22 @@ internal data class ChainTransaction(
 )
 
 /**
+ * Aggregate light/network profile of the tasks currently pending in the dynamic-task queue.
+ * See [IosFileStorage.getDynamicQueueConstraintSummary].
+ */
+internal data class DynamicQueueConstraintSummary(
+    val pendingCount: Int,
+    val heavyCount: Int,
+    val networkRequiredCount: Int
+) {
+    /** True when every pending task is light — safe to schedule as `BGAppRefreshTask`. */
+    val allLight: Boolean get() = pendingCount > 0 && heavyCount == 0
+
+    /** True when every pending task requires network connectivity. */
+    val allRequireNetwork: Boolean get() = pendingCount > 0 && networkRequiredCount == pendingCount
+}
+
+/**
  * Configuration for [IosFileStorage].
  *
  * @param diskSpaceBufferBytes Minimum free space required before any write (safety margin).
@@ -513,6 +529,36 @@ public class IosFileStorage(
      * which is acceptable since getQueueSize() is called infrequently (once per BGTask).
      */
     suspend fun getQueueSize(): Int = queue.getSize()
+
+    /**
+     * Aggregate light/network profile of every task currently sitting in the dynamic-task
+     * queue. Lets the master dispatcher be scheduled with constraints that actually match
+     * what's pending, instead of always requesting an unconstrained `BGProcessingTask`.
+     * See docs/ios-dynamic-task-scheduling.md § 5.
+     *
+     * Always reads from disk (like [getQueueSize]) — the same multi-instance staleness
+     * concern applies, and this is called once per master-dispatcher schedule decision,
+     * not per task, so the extra I/O is acceptable.
+     *
+     * **Performance**: O(N) on queue size (bounded by [MAX_QUEUE_SIZE]) — one metadata
+     * read per pending task.
+     */
+    internal suspend fun getDynamicQueueConstraintSummary(): DynamicQueueConstraintSummary {
+        val ids = tasksQueue.getAllItems()
+        var heavyCount = 0
+        var networkCount = 0
+        for (id in ids) {
+            // A dynamic task ID is either one-time or periodic metadata — never both.
+            val meta = loadTaskMetadata(id, periodic = false) ?: loadTaskMetadata(id, periodic = true)
+            if (meta?.get("isHeavyTask") == "true") heavyCount++
+            if (meta?.get("requiresNetwork") == "true") networkCount++
+        }
+        return DynamicQueueConstraintSummary(
+            pendingCount = ids.size,
+            heavyCount = heavyCount,
+            networkRequiredCount = networkCount
+        )
+    }
 
     /**
      * Sort the execution queue by task priority (highest first).

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -607,18 +607,38 @@ public class NativeTaskScheduler(
     }
 
     /**
-     * Returns the earliestBeginDate of the currently-pending Master Dispatcher request,
-     * or null if no such request is pending (or in test mode).
-     * Used to avoid pushing back the dispatcher when a later-dated dynamic task is enqueued.
+     * Snapshot of the currently-pending Master Dispatcher request, or null if none is
+     * pending (or in test mode). The dispatcher is always a `BGProcessingTaskRequest`
+     * (see [submitTaskRequest]'s dynamic-task branch for why it never becomes a
+     * `BGAppRefreshTaskRequest`); [requiresNetwork] lets that branch decide whether the
+     * aggregate queue profile now needs a different `requiresNetworkConnectivity` value,
+     * not just a date change.
      */
-    private suspend fun getPendingMasterDispatcherDate(): NSDate? {
+    private data class PendingMasterDispatcherInfo(
+        val earliestBeginDate: NSDate?,
+        val requiresNetwork: Boolean
+    )
+
+    /**
+     * Returns a snapshot of the currently-pending Master Dispatcher request (date +
+     * requiresNetworkConnectivity), or null if none is pending.
+     * Used to avoid pushing back the dispatcher when a later-dated dynamic task is enqueued,
+     * and to detect when the aggregate queue profile now requires a different network flag.
+     */
+    private suspend fun getPendingMasterDispatcherInfo(): PendingMasterDispatcherInfo? {
         if (NSBundle.mainBundle.bundleIdentifier == null) return null
         return suspendCancellableCoroutine { continuation ->
             BGTaskScheduler.sharedScheduler.getPendingTaskRequestsWithCompletionHandler { requests ->
                 if (continuation.isActive) {
-                    val master = requests?.filterIsInstance<BGTaskRequest>()
+                    val master = requests?.filterIsInstance<BGProcessingTaskRequest>()
                         ?.find { it.identifier == MASTER_DISPATCHER_IDENTIFIER }
-                    continuation.resume(master?.earliestBeginDate)
+                    val info = master?.let {
+                        PendingMasterDispatcherInfo(
+                            earliestBeginDate = it.earliestBeginDate,
+                            requiresNetwork = it.requiresNetworkConnectivity
+                        )
+                    }
+                    continuation.resume(info)
                 }
             }
             continuation.invokeOnCancellation { }
@@ -666,21 +686,53 @@ public class NativeTaskScheduler(
 
                 val proposedDate = request.earliestBeginDate
 
-                // Only reschedule Master Dispatcher if the proposed date is earlier than the
-                // currently-pending one. Submitting a later date silently replaces an earlier
-                // pending request, delaying tasks already waiting in the queue.
-                val existingMasterDate = getPendingMasterDispatcherDate()
-                if (existingMasterDate != null && proposedDate != null &&
-                    proposedDate.timeIntervalSinceDate(existingMasterDate) >= 0) {
+                // Derive the Master Dispatcher's requiresNetworkConnectivity from what's
+                // actually pending now (including the task just enqueued above), instead of
+                // always submitting unconstrained. See docs/ios-dynamic-task-scheduling.md § 5.
+                //
+                // NOTE: the dispatcher always stays a BGProcessingTaskRequest here — it does
+                // NOT switch to BGAppRefreshTaskRequest for all-light queues. That looked like
+                // the obvious next step but isn't safe with the current batch executor:
+                // BGAppRefreshTask has a hard ~30s ceiling with no extension API
+                // (docs/IOS_BGTASK_LIMITS.md § 1), while a single dequeued task may run up to
+                // SingleTaskExecutor.DEFAULT_TIMEOUT_MS (25s) — there's no safe margin left for
+                // wake latency + completion overhead, let alone a second task in the batch.
+                // Tracked as follow-up scope in issue #79.
+                val summary = fileStorage.getDynamicQueueConstraintSummary()
+                val desiredRequiresNetwork = summary.allRequireNetwork
+
+                val existing = getPendingMasterDispatcherInfo()
+                val existingDate = existing?.earliestBeginDate
+                val proposedIsNotEarlier = existingDate != null && proposedDate != null &&
+                    proposedDate.timeIntervalSinceDate(existingDate) >= 0
+                val networkFlagUnchanged = existing != null && existing.requiresNetwork == desiredRequiresNetwork
+
+                // Only reschedule the Master Dispatcher if the proposed date is earlier than the
+                // currently-pending one, OR the aggregate queue profile now needs a different
+                // requiresNetworkConnectivity value. Submitting a later date (with no flag
+                // change) would silently replace an earlier pending request, delaying tasks
+                // already waiting.
+                if (existing != null && proposedIsNotEarlier && networkFlagUnchanged) {
                     Logger.d(LogTags.SCHEDULER,
-                        "Master Dispatcher already scheduled earlier — keeping existing schedule for '$id'")
+                        "Master Dispatcher already scheduled earlier with matching constraints — keeping existing schedule for '$id'")
                     return ScheduleResult.ACCEPTED
                 }
 
+                // When resubmitting, never regress an earlier date already pending — the same
+                // identifier replaces the old request on submit regardless of date, so pick the
+                // earlier of the two if both exist.
+                val earliestBeginDate = when {
+                    existingDate != null && proposedDate != null ->
+                        if (existingDate.timeIntervalSinceDate(proposedDate) < 0) existingDate else proposedDate
+                    existingDate != null -> existingDate
+                    else -> proposedDate
+                }
+
+                Logger.d(LogTags.SCHEDULER, "Master Dispatcher: BGProcessingTaskRequest (requiresNetwork=$desiredRequiresNetwork)")
                 val masterRequest = BGProcessingTaskRequest(MASTER_DISPATCHER_IDENTIFIER).apply {
-                    requiresNetworkConnectivity = false
+                    requiresNetworkConnectivity = desiredRequiresNetwork
                     requiresExternalPower = false
-                    earliestBeginDate = proposedDate
+                    this.earliestBeginDate = earliestBeginDate
                 }
 
                 return submitTaskRequest(masterRequest, "Master Dispatcher for task '$id'")

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/MasterDispatcherConstraintSummaryTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/MasterDispatcherConstraintSummaryTest.kt
@@ -1,0 +1,148 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
+package dev.brewkits.kmpworkmanager
+
+import dev.brewkits.kmpworkmanager.background.data.*
+import kotlinx.coroutines.test.runTest
+import platform.Foundation.*
+import kotlin.test.*
+
+/**
+ * Covers [IosFileStorage.getDynamicQueueConstraintSummary] — the aggregate
+ * light/network profile the Master Dispatcher uses to pick between an unconstrained
+ * `BGProcessingTaskRequest` and a cheaper, better-scheduled `BGAppRefreshTaskRequest`.
+ *
+ * Background: raised in
+ * https://github.com/brewkits/kmpworkmanager/discussions/78 and tracked as
+ * https://github.com/brewkits/kmpworkmanager/issues/79 — the dispatcher previously
+ * always requested an unconstrained `BGProcessingTaskRequest`, even when every pending
+ * dynamic task was light and network-dependent. See
+ * docs/ios-dynamic-task-scheduling.md § 5.
+ */
+class MasterDispatcherConstraintSummaryTest {
+
+    private fun makeTempDir(tag: String): NSURL {
+        val base = NSTemporaryDirectory()
+        val name = "kmp_master_dispatcher_summary_${tag}_${(NSDate().timeIntervalSince1970 * 1000).toLong()}_${platform.posix.rand()}"
+        val url = NSURL.fileURLWithPath("$base$name")
+        NSFileManager.defaultManager.createDirectoryAtURL(url, withIntermediateDirectories = true, attributes = null, error = null)
+        return url
+    }
+
+    private fun makeStorage(tag: String): IosFileStorage {
+        return IosFileStorage(
+            config = IosFileStorageConfig(isTestMode = true),
+            baseDirectory = makeTempDir(tag)
+        )
+    }
+
+    private fun metaFor(requiresNetwork: Boolean, isHeavyTask: Boolean): Map<String, String> = mapOf(
+        "workerClassName" to "EchoWorker",
+        "requiresNetwork" to "$requiresNetwork",
+        "requiresCharging" to "false",
+        "isHeavyTask" to "$isHeavyTask"
+    )
+
+    @Test
+    fun `empty queue reports no pending tasks and is not all-light or all-network`() = runTest {
+        val storage = makeStorage("empty")
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(0, summary.pendingCount)
+        assertFalse(summary.allLight, "an empty queue has nothing to schedule as BGAppRefreshTask")
+        assertFalse(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `queue of only light network tasks is reported all-light and all-network`() = runTest {
+        val storage = makeStorage("all-light-network")
+
+        storage.enqueueTask("light-net-1")
+        storage.saveTaskMetadata("light-net-1", metaFor(requiresNetwork = true, isHeavyTask = false), periodic = false)
+        storage.enqueueTask("light-net-2")
+        storage.saveTaskMetadata("light-net-2", metaFor(requiresNetwork = true, isHeavyTask = false), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(2, summary.pendingCount)
+        assertTrue(summary.allLight, "all queued tasks are light — dispatcher should use BGAppRefreshTaskRequest")
+        assertTrue(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `a single heavy task among light ones flips allLight to false`() = runTest {
+        val storage = makeStorage("mixed-heavy")
+
+        storage.enqueueTask("light-1")
+        storage.saveTaskMetadata("light-1", metaFor(requiresNetwork = false, isHeavyTask = false), periodic = false)
+        storage.enqueueTask("heavy-1")
+        storage.saveTaskMetadata("heavy-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(2, summary.pendingCount)
+        assertFalse(summary.allLight, "one heavy task in the queue means BGProcessingTaskRequest is still required")
+    }
+
+    @Test
+    fun `mixed network requirements are not reported as all-network`() = runTest {
+        val storage = makeStorage("mixed-network")
+
+        storage.enqueueTask("net-1")
+        storage.saveTaskMetadata("net-1", metaFor(requiresNetwork = true, isHeavyTask = true), periodic = false)
+        storage.enqueueTask("offline-ok-1")
+        storage.saveTaskMetadata("offline-ok-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertFalse(
+            summary.allRequireNetwork,
+            "requiresNetworkConnectivity=true would wrongly block the offline-capable task too"
+        )
+    }
+
+    @Test
+    fun `periodic dynamic task metadata is also aggregated`() = runTest {
+        val storage = makeStorage("periodic")
+
+        storage.enqueueTask("periodic-light")
+        storage.saveTaskMetadata(
+            "periodic-light",
+            mapOf(
+                "isPeriodic" to "true",
+                "intervalMs" to "60000",
+                "anchoredStartMs" to "0",
+                "workerClassName" to "EchoWorker",
+                "requiresNetwork" to "true",
+                "requiresCharging" to "false",
+                "isHeavyTask" to "false"
+            ),
+            periodic = true
+        )
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+
+        assertEquals(1, summary.pendingCount)
+        assertTrue(summary.allLight)
+        assertTrue(summary.allRequireNetwork)
+    }
+
+    @Test
+    fun `dequeued tasks drop out of the aggregate`() = runTest {
+        val storage = makeStorage("dequeue")
+
+        storage.enqueueTask("heavy-1")
+        storage.saveTaskMetadata("heavy-1", metaFor(requiresNetwork = false, isHeavyTask = true), periodic = false)
+        storage.enqueueTask("light-1")
+        storage.saveTaskMetadata("light-1", metaFor(requiresNetwork = false, isHeavyTask = false), periodic = false)
+
+        assertFalse(storage.getDynamicQueueConstraintSummary().allLight)
+
+        assertEquals("heavy-1", storage.dequeueTask())
+
+        val summary = storage.getDynamicQueueConstraintSummary()
+        assertEquals(1, summary.pendingCount)
+        assertTrue(summary.allLight, "after the heavy task is dequeued, only the light task remains")
+    }
+}


### PR DESCRIPTION
Combines #80, #83, #84 into one branch for a single review pass. Each PR stays open individually with its own detailed description — this is a merge convenience, not a replacement. Once reviewed/approved, merging this closes all three (or merge them individually and close this one, whichever the reviewer prefers).

## Contents

- **#80** — fix(ios): derive master dispatcher `requiresNetworkConnectivity` from pending queue (discussion #78 / issue #79)
- **#84** — feat(http): HMAC-SHA256 request signing + token refresh on 401 (issue #81)
- **#83** — docs(roadmap): prioritize HTTP worker parity + Gradle plugin as next up

## Verification on the combined branch

All three merged cleanly with no conflicts (verified via `git merge --no-ff` for each). Re-ran the full suite on the merged result, not just each branch individually:

- `:kmpworker:iosSimulatorArm64Test` — 893 tests, 0 failures
- `:kmpworker-http:iosSimulatorArm64Test` — 64 tests, 0 failures
- `:kmpworker:testDebugUnitTest` / `:kmpworker-http:testDebugUnitTest` — green
- Both modules compile clean on Android + iOS Simulator targets

See the individual PRs (#80, #83, #84) for per-change rationale, design notes, and security-review fixes.
