### PR TITLE
feat(android): diagnose foregroundServiceType manifest mismatches (#82)

### DIFF
--- a/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpHeavyWorker.kt
+++ b/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpHeavyWorker.kt
@@ -2,7 +2,9 @@ package dev.brewkits.kmpworkmanager.background.data
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
@@ -54,6 +56,14 @@ open class KmpHeavyWorker(
     companion object {
         private const val NOTIFICATION_CHANNEL_ID = "kmp_heavy_worker_channel"
         private const val NOTIFICATION_ID = 1001
+
+        /**
+         * The service `androidx.work` declares in its own AAR manifest — every app depending
+         * on `work-runtime` merges this into its final manifest automatically, so it's always
+         * present with SOME `foregroundServiceType`, never a component the host app authored
+         * itself. Used to read the app's actual merged FGS type declaration for diagnostics.
+         */
+        private const val SYSTEM_FOREGROUND_SERVICE_CLASS = "androidx.work.impl.foreground.SystemForegroundService"
 
         /**
          * Convenience aliases for the most common FGS types. These are the same integer
@@ -113,6 +123,39 @@ open class KmpHeavyWorker(
     override val workerLogTag: String get() = "KmpHeavyWorker"
 
     override suspend fun doWork(): Result {
+        // Diagnostic-only, best-effort read of the manifest's actual declared FGS type(s) for
+        // this app. Never throws and never affects control flow on its own — a
+        // getServiceInfo() failure (component genuinely absent, PackageManager quirk on a
+        // given OEM, …) must not turn a worker that would otherwise succeed into a failure.
+        // See docs/ROADMAP.md "Android FGS-type diagnosability" (#82) for why this exists:
+        // the pre-fix exception message below named only what THIS worker declared, not
+        // what the manifest actually has, and on API 29-33 a mismatch doesn't throw at all
+        // (ForegroundServiceTypeException is API 34+) — proactively warn there since
+        // nothing else will.
+        //
+        // `foregroundServiceType` on <service> is an OR-bitmask of possibly several types
+        // (docs/ANDROID_FGS_GUIDE.md's own examples declare e.g. "dataSync|camera" so one
+        // service backs workers of different types) — so this worker's single declared type
+        // must be present as a BIT in the manifest value, not equal to it. `!=` here would
+        // false-positive on every multi-type manifest, which is the guide's own recommended
+        // pattern, and API < 29 or a manifest that omits foregroundServiceType entirely reads
+        // back as `0` (FOREGROUND_SERVICE_TYPE_NONE / "manifest" default) — `0 != anything`
+        // would also false-positive on every app that hasn't set a type at all, which is
+        // common and not itself a mismatch worth warning about (only a positive, wrong bit is).
+        val manifestFgsType = readManifestForegroundServiceType()
+        if (manifestFgsType != null && manifestFgsType != 0 && (manifestFgsType and foregroundServiceType) == 0 &&
+            Build.VERSION.SDK_INT in Build.VERSION_CODES.Q until Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Logger.w(
+                LogTags.WORKER,
+                "foregroundServiceType mismatch: worker declares $foregroundServiceType but the " +
+                    "manifest's <service android:foregroundServiceType=…> declares $manifestFgsType " +
+                    "(a bitmask — this worker's type is not one of the bits set there). " +
+                    "On this OS version (API ${Build.VERSION.SDK_INT}, below Android 14) a mismatch " +
+                    "does NOT throw — the FGS silently starts with the manifest's type instead of the " +
+                    "one this worker expects. See docs/ANDROID_FGS_GUIDE.md.",
+            )
+        }
+
         // Handle Android 14+ FGS exceptions gracefully to prevent WorkManager crashes.
         // Translates raw exceptions into Result.failure() with diagnostic logs.
         try {
@@ -122,7 +165,8 @@ open class KmpHeavyWorker(
                 LogTags.WORKER,
                 "Foreground service start denied (SecurityException). " +
                     "Type=$foregroundServiceType requires a matching FOREGROUND_SERVICE_<TYPE> " +
-                    "permission in AndroidManifest.xml. See docs/ANDROID_FGS_GUIDE.md.",
+                    "permission in AndroidManifest.xml.${manifestTypeSuffix(manifestFgsType)} " +
+                    "See docs/ANDROID_FGS_GUIDE.md.",
                 e,
             )
             return Result.failure()
@@ -135,7 +179,8 @@ open class KmpHeavyWorker(
                     "This typically means: (a) the host app is in a state where it cannot start " +
                     "an FGS (background-without-special-permission), OR (b) the FGS type " +
                     "$foregroundServiceType is not declared on <service android:foregroundServiceType=…> " +
-                    "in the manifest. See docs/ANDROID_FGS_GUIDE.md for type-by-type setup.",
+                    "in the manifest.${manifestTypeSuffix(manifestFgsType)} " +
+                    "See docs/ANDROID_FGS_GUIDE.md for type-by-type setup.",
                 e,
             )
             return Result.failure()
@@ -192,4 +237,37 @@ open class KmpHeavyWorker(
             ForegroundInfo(NOTIFICATION_ID, notification)
         }
     }
+
+    /**
+     * Reads the `android:foregroundServiceType` this app's manifest actually declares for
+     * WorkManager's `SystemForegroundService` — via [PackageManager.getServiceInfo], which
+     * returns the fully merged manifest, not the source `AndroidManifest.xml` fragment this
+     * library or the host app authored in isolation.
+     *
+     * Best-effort and diagnostic-only: returns `null` on ANY failure (component genuinely
+     * absent — shouldn't happen since `androidx.work` declares it, but a `NameNotFoundException`
+     * or OEM `PackageManager` quirk must not throw out of `doWork()`) or below API 29, where
+     * `ServiceInfo.foregroundServiceType` doesn't exist. Callers must treat `null` as
+     * "unknown," never as "zero" or "mismatch."
+     */
+    private fun readManifestForegroundServiceType(): Int? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+        return try {
+            val component = ComponentName(applicationContext, SYSTEM_FOREGROUND_SERVICE_CLASS)
+            val info = applicationContext.packageManager.getServiceInfo(component, PackageManager.GET_SERVICES)
+            info.foregroundServiceType
+        } catch (e: Exception) {
+            Logger.d(LogTags.WORKER, "Could not read manifest foregroundServiceType (non-fatal, diagnostics only): ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Appends the manifest's actual declared type bitmask to a diagnostic message, when
+     * known. Note this is a bitmask (possibly several `FOREGROUND_SERVICE_TYPE_*` bits
+     * OR'd together on a shared `<service>` — see docs/ANDROID_FGS_GUIDE.md), not
+     * necessarily equal to this worker's single [foregroundServiceType].
+     */
+    private fun manifestTypeSuffix(manifestFgsType: Int?): String =
+        if (manifestFgsType != null) " Manifest currently declares type bitmask=$manifestFgsType." else ""
 }

--- a/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpHeavyWorkerManifestDiagnosticsTest.kt
+++ b/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/KmpHeavyWorkerManifestDiagnosticsTest.kt
@@ -1,0 +1,210 @@
+package dev.brewkits.kmpworkmanager.background.data
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.ServiceInfo
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorker
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorkerFactory
+import dev.brewkits.kmpworkmanager.background.domain.WorkerEnvironment
+import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for #82's revised scope: [KmpHeavyWorker] reading the app's actual merged
+ * `android:foregroundServiceType` manifest declaration for diagnostics.
+ *
+ * Background: pre-fix, `KmpHeavyWorker`'s `setForeground()` exception handler named only
+ * what the worker itself declared via [KmpHeavyWorker.foregroundServiceType] — a developer
+ * debugging a mismatch had to separately go read the manifest to compare. Below API 34
+ * (`ForegroundServiceTypeException` is API 34+), a mismatch doesn't throw at ALL, so nothing
+ * surfaced it. See `docs/ROADMAP.md` "Android FGS-type diagnosability".
+ *
+ * `SystemForegroundService` (from `androidx.work`) is always present in a real merged
+ * manifest — apps depending on `work-runtime` get it automatically — but Robolectric's
+ * `ShadowPackageManager` doesn't parse the dependency AAR's manifest into its package
+ * registry, so each test registers it explicitly via `addOrUpdateService` to simulate
+ * exactly what a real device sees.
+ */
+@RunWith(RobolectricTestRunner::class)
+class KmpHeavyWorkerManifestDiagnosticsTest {
+
+    private object NoopAndroidFactory : AndroidWorkerFactory {
+        override fun createWorker(workerClassName: String): AndroidWorker? = SuccessWorker
+    }
+
+    private object SuccessWorker : AndroidWorker {
+        override suspend fun doWork(input: String?, env: WorkerEnvironment): WorkerResult =
+            WorkerResult.Success("ok")
+    }
+
+    private class TestFactory : WorkerFactory() {
+        override fun createWorker(
+            appContext: Context,
+            workerClassName: String,
+            workerParameters: WorkerParameters
+        ): ListenableWorker = KmpHeavyWorker(appContext, workerParameters, NoopAndroidFactory)
+    }
+
+    private fun registerSystemForegroundService(context: Context, foregroundServiceType: Int) {
+        val info = ServiceInfo().apply {
+            packageName = context.packageName
+            name = "androidx.work.impl.foreground.SystemForegroundService"
+        }
+        // ServiceInfo.foregroundServiceType has only a public getter on the compile-time SDK
+        // stub — there's no public setter/field to assign directly. The Robolectric-
+        // instrumented runtime class backs it with a public field named `mForegroundServiceType`
+        // (not `foregroundServiceType`), so it's set via reflection here, matching what a real
+        // manifest merge into a `ServiceInfo` would ultimately populate.
+        val field = ServiceInfo::class.java.getDeclaredField("mForegroundServiceType")
+        field.isAccessible = true
+        field.setInt(info, foregroundServiceType)
+        Shadows.shadowOf(context.packageManager).addOrUpdateService(info)
+    }
+
+    private fun buildWorker(context: Context): KmpHeavyWorker =
+        TestListenableWorkerBuilder<KmpHeavyWorker>(context)
+            .setWorkerFactory(TestFactory())
+            // BaseKmpWorker.doWorkInternal() reads workerClassName from inputData and
+            // returns Result.failure() immediately if it's absent — unrelated to anything
+            // this test covers, but required for doWork() to reach the FGS code at all.
+            .setInputData(Data.Builder().putString("workerClassName", "SuccessWorker").build())
+            .build()
+
+    @Config(sdk = [30]) // API 30: within 29-33, no ForegroundServiceTypeException exists
+    @Test
+    fun api29to33_mismatchedManifestType_logsProactiveWarning() {
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // Worker declares dataSync (KmpHeavyWorker's default) but the manifest says camera.
+        registerSystemForegroundService(context, ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA)
+        val worker = buildWorker(context)
+
+        runBlocking { worker.doWork() }
+
+        val warned = ShadowLog.getLogs().any {
+            it.msg.contains("foregroundServiceType mismatch") && it.msg.contains("does NOT throw")
+        }
+        assertTrue(warned, "expected a proactive mismatch warning on API 29-33 where nothing else surfaces this")
+    }
+
+    @Config(sdk = [30])
+    @Test
+    fun api29to33_matchingManifestType_noWarningLogged() {
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        registerSystemForegroundService(context, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        val worker = buildWorker(context)
+
+        runBlocking { worker.doWork() }
+
+        val warned = ShadowLog.getLogs().any { it.msg.contains("foregroundServiceType mismatch") }
+        assertTrue(!warned, "a matching manifest declaration must not trigger the mismatch warning")
+    }
+
+    @Config(sdk = [30])
+    @Test
+    fun api29to33_multiTypeManifestContainingWorkersType_noFalsePositive() {
+        // docs/ANDROID_FGS_GUIDE.md's own recommended pattern for a shared <service>: OR
+        // several types together, e.g. android:foregroundServiceType="dataSync|camera", so
+        // one service backs workers of different declared types. The manifest value here is
+        // NOT equal to the worker's single declared type, but DOES contain it as a bit — this
+        // must NOT warn. This is the exact false-positive an equality check would produce.
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val multiType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+        registerSystemForegroundService(context, multiType)
+        val worker = buildWorker(context) // declares DATA_SYNC (KmpHeavyWorker's default)
+
+        runBlocking { worker.doWork() }
+
+        val warned = ShadowLog.getLogs().any { it.msg.contains("foregroundServiceType mismatch") }
+        assertTrue(!warned, "worker's declared type IS one of the manifest's OR'd bits — must not warn")
+    }
+
+    @Config(sdk = [30])
+    @Test
+    fun api29to33_manifestDeclaresNoType_noFalsePositive() {
+        // A manifest that never sets android:foregroundServiceType reads back as 0
+        // (FOREGROUND_SERVICE_TYPE_NONE / the "manifest" default) — common for apps that
+        // predate this feature or haven't adopted it. That's a real gap worth fixing, but
+        // it isn't a "worker declared X, manifest declared Y" MISMATCH — the diagnostic
+        // must not conflate "not configured" with "configured wrong."
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        registerSystemForegroundService(context, 0)
+        val worker = buildWorker(context)
+
+        runBlocking { worker.doWork() }
+
+        val warned = ShadowLog.getLogs().any { it.msg.contains("foregroundServiceType mismatch") }
+        assertTrue(!warned, "manifest type=0 (unset) must not be reported as a mismatch")
+    }
+
+    @Config(sdk = [34]) // API 34+: mismatch throws ForegroundServiceTypeException — no proactive warning needed
+    @Test
+    fun api34Plus_mismatchedManifestType_noProactiveWarning_relyOnException() {
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        registerSystemForegroundService(context, ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA)
+        val worker = buildWorker(context)
+
+        runBlocking { worker.doWork() }
+
+        // The proactive warning is scoped to API 29-33 only — API 34+ has its own throw path
+        // (covered by the pre-existing setForeground() catch block), so this must NOT also
+        // fire the same warning; that would be a redundant/confusing double-signal.
+        val warned = ShadowLog.getLogs().any { it.msg.contains("foregroundServiceType mismatch") }
+        assertTrue(!warned, "API 34+ has its own exception path — the proactive warning must not duplicate it")
+    }
+
+    @Config(sdk = [30])
+    @Test
+    fun manifestReadFailure_neverThrows_workerStillProceeds() {
+        // Deliberately do NOT register SystemForegroundService — simulates a
+        // NameNotFoundException from getServiceInfo(). Must degrade to "unknown" (null),
+        // never propagate as a worker failure.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val worker = buildWorker(context)
+
+        val result = runBlocking { worker.doWork() }
+
+        // ListenableWorker.Result has no public equals-friendly subtype check via kotlin.test
+        // assertIs is avoided to keep this test independent of androidx.work internals beyond
+        // what's already used elsewhere in this suite — string form is asserted instead.
+        assertTrue(
+            result.toString().contains("Success", ignoreCase = true),
+            "a manifest read failure must not fail the worker — got: $result"
+        )
+    }
+
+    @Config(sdk = [28]) // Below API 29: ServiceInfo.foregroundServiceType doesn't exist yet
+    @Test
+    fun belowApi29_neverAttemptsManifestRead_doesNotCrash_noWarning() {
+        ShadowLog.clear()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // No SystemForegroundService registered — if the below-Q guard were missing, calling
+        // getServiceInfo() here would hit the same NameNotFoundException path exercised by
+        // manifestReadFailure_neverThrows_workerStillProceeds above. This test instead pins
+        // that the guard skips the attempt entirely on this API level.
+        val worker = buildWorker(context)
+
+        val result = runBlocking { worker.doWork() }
+
+        assertTrue(result.toString().contains("Success", ignoreCase = true))
+        val warned = ShadowLog.getLogs().any { it.msg.contains("foregroundServiceType mismatch") }
+        assertTrue(!warned, "the proactive warning is scoped to API 29+ (ServiceInfo.foregroundServiceType doesn't exist below it)")
+    }
+}


### PR DESCRIPTION
## What

Ships #82's corrected scope: `KmpHeavyWorker.doWork()` now reads the app's actual merged manifest declaration for `foregroundServiceType` (via `PackageManager.getServiceInfo()` on WorkManager's `SystemForegroundService`) and uses it purely for diagnostics — enriching the existing `setForeground()` exception log and, on API 29-33, proactively warning about a mismatch that would otherwise never surface at all.

## Why the scope changed from #82's original proposal

The original issue proposed a Gradle plugin generating/validating `Info.plist`/Manifest entries from `@Worker` annotations. Investigation found:
- **iOS needed nothing** — `@Worker(bgTaskId=…)` already `require()`-crashes at `KmpWorkManager.initialize()` via the KSP-generated `BgTaskIdProvider`.
- **A Gradle plugin can't reliably cover Android** — `@Worker` is `SOURCE`-retention (invisible to a Gradle plugin without a new KSP-output pipeline), and `foregroundServiceType` is a computed `open val`, not a literal a plugin could resolve.
- **What Android actually has**: `KmpHeavyWorker.doWork()` already catches and logs the `setForeground()` exception clearly — the real gap is narrower: the message names only what the worker declared, not what the manifest has, and API 29-33 doesn't throw on a mismatch at all (`ForegroundServiceTypeException` is API 34+).

Full writeup in the issue and `docs/ROADMAP.md`.

## A bug caught mid-implementation, worth flagging in review

My first pass compared the manifest's declared type to the worker's declared type with `!=`. That's wrong: `android:foregroundServiceType` is an **OR-bitmask** — `docs/ANDROID_FGS_GUIDE.md`'s own examples declare `dataSync|camera` on a shared `<service>` so one service backs workers of different declared types. An equality check would have false-positived on:
- every manifest following the guide's own multi-type pattern, and
- every app that hasn't declared a type at all (reads back as `0`, not itself a mismatch).

Fixed to a bitwise `AND` against the worker's single declared type, with `manifestFgsType != 0` guarding the "not configured" case separately from "configured wrong." Added two tests (`api29to33_multiTypeManifestContainingWorkersType_noFalsePositive`, `api29to33_manifestDeclaresNoType_noFalsePositive`) pinning both cases.

## Testing

`./gradlew :kmpworker:testDebugUnitTest` — full suite green, including 7 new Robolectric tests covering: mismatch warning on API 29-33, no warning on a match, no warning on a multi-type manifest containing the worker's bit, no warning on an unconfigured (`0`) manifest, no duplicate warning on API 34+ (relies on the existing exception path instead), a `getServiceInfo()` failure never failing the worker, and the below-API-29 guard never attempting the read.
