### PR TITLE
fix(android): stamp real chainId/stepIndex into chain-step telemetry and history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to KMP WorkManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Android: chain-member tasks never reported `chainId`/`stepIndex` in telemetry, and
+  `ExecutionRecord.chainId` held the wrong ID.** Found by manually running the demo app's
+  Sequential chain and reading its logs: every `TaskStartedEvent` logged `chain=null
+  step=null` even for genuine chain-member tasks. Root cause: WorkManager's native
+  `then()`-chaining carries no chain metadata of its own — `enqueueChain()` never stamped
+  it into a step's `inputData`, so `BaseKmpWorker` had nothing to read (iOS's
+  `ChainExecutor` has always done this correctly). `ExecutionRecord.chainId` was also
+  populated with `ListenableWorker.id` (WorkManager's per-request random UUID) instead of
+  the ID passed to `TaskChain.withId()`. `enqueueChain()` now stamps namespaced
+  `kmp_chain_id`/`kmp_step_index`/`kmp_total_steps` keys per step; `BaseKmpWorker` reads
+  them back for `TaskStartedEvent`/`TaskCompletedEvent`/`TaskFailedEvent` and
+  `ExecutionRecord`. Standalone tasks are unaffected. See
+  [#87](https://github.com/brewkits/kmpworkmanager/pull/87).
+
 ## [3.3.1] - 2026-08-09
 
 A senior mobile QA/QC review pass across the whole library surfaced five further findings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the ID passed to `TaskChain.withId()`. `enqueueChain()` now stamps namespaced
   `kmp_chain_id`/`kmp_step_index`/`kmp_total_steps` keys per step; `BaseKmpWorker` reads
   them back for `TaskStartedEvent`/`TaskCompletedEvent`/`TaskFailedEvent` and
-  `ExecutionRecord`. Standalone tasks are unaffected. See
+  `ExecutionRecord`. Standalone tasks are unaffected. **Behavior change:**
+  `ExecutionRecord.failedStep` on Android was previously always `0` on failure; it now
+  reports the real 0-based step index that failed (still `0` for standalone tasks). See
   [#87](https://github.com/brewkits/kmpworkmanager/pull/87).
 
 ## [3.3.1] - 2026-08-09

--- a/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/BaseKmpWorker.kt
+++ b/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/BaseKmpWorker.kt
@@ -105,6 +105,12 @@ abstract class BaseKmpWorker : CoroutineWorker {
         val workerClassName = inputData.getString("workerClassName")
             ?: return Result.failure()
 
+        // Chain identity, stamped by NativeTaskScheduler.enqueueChain() for chain-member tasks
+        // only; absent (null) for standalone one-time/periodic/exact-alarm tasks.
+        val chainId = inputData.getString(NativeTaskScheduler.KEY_CHAIN_ID)
+        val stepIndex = inputData.getInt(NativeTaskScheduler.KEY_STEP_INDEX, -1).takeIf { it >= 0 }
+        val totalSteps = inputData.getInt(NativeTaskScheduler.KEY_TOTAL_STEPS, -1).takeIf { it >= 0 }
+
         val startTime = System.currentTimeMillis()
         var isRetrying = false
         var wasCancelled = false
@@ -114,6 +120,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
         KmpWorkManagerRuntime.notifyTaskStarted(
             TelemetryHook.TaskStartedEvent(
                 taskName = workerClassName,
+                chainId = chainId,
+                stepIndex = stepIndex,
                 platform = "android",
                 startedAtMs = startTime
             )
@@ -148,6 +156,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
                     KmpWorkManagerRuntime.notifyTaskCompleted(
                         TelemetryHook.TaskCompletedEvent(
                             taskName = workerClassName,
+                            chainId = chainId,
+                            stepIndex = stepIndex,
                             platform = "android",
                             success = true,
                             durationMs = duration
@@ -170,6 +180,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
                     KmpWorkManagerRuntime.notifyTaskCompleted(
                         TelemetryHook.TaskCompletedEvent(
                             taskName = workerClassName,
+                            chainId = chainId,
+                            stepIndex = stepIndex,
                             platform = "android",
                             success = false,
                             durationMs = duration,
@@ -179,6 +191,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
                     KmpWorkManagerRuntime.notifyTaskFailed(
                         TelemetryHook.TaskFailedEvent(
                             taskName = workerClassName,
+                            chainId = chainId,
+                            stepIndex = stepIndex,
                             platform = "android",
                             error = result.message,
                             durationMs = duration,
@@ -242,6 +256,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
                         KmpWorkManagerRuntime.notifyTaskFailed(
                             TelemetryHook.TaskFailedEvent(
                                 taskName = workerClassName,
+                                chainId = chainId,
+                                stepIndex = stepIndex,
                                 platform = "android",
                                 error = "Retry cap reached: ${result.reason}",
                                 durationMs = duration,
@@ -260,6 +276,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
                     KmpWorkManagerRuntime.notifyTaskFailed(
                         TelemetryHook.TaskFailedEvent(
                             taskName = workerClassName,
+                            chainId = chainId,
+                            stepIndex = stepIndex,
                             platform = "android",
                             error = "Retry requested: ${result.reason}",
                             durationMs = duration,
@@ -307,6 +325,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
             KmpWorkManagerRuntime.notifyTaskCompleted(
                 TelemetryHook.TaskCompletedEvent(
                     taskName = workerClassName,
+                    chainId = chainId,
+                    stepIndex = stepIndex,
                     platform = "android",
                     success = false,
                     durationMs = duration,
@@ -316,6 +336,8 @@ abstract class BaseKmpWorker : CoroutineWorker {
             KmpWorkManagerRuntime.notifyTaskFailed(
                 TelemetryHook.TaskFailedEvent(
                     taskName = workerClassName,
+                    chainId = chainId,
+                    stepIndex = stepIndex,
                     platform = "android",
                     error = e.message ?: "Unknown exception",
                     durationMs = duration,
@@ -356,14 +378,23 @@ abstract class BaseKmpWorker : CoroutineWorker {
                         KmpWorkManagerRuntime.executionHistoryStore?.save(
                             ExecutionRecord(
                                 id = java.util.UUID.randomUUID().toString(),
-                                chainId = id.toString(),
+                                // Real chain ID for chain-member tasks (see NativeTaskScheduler.
+                                // enqueueChain's KEY_CHAIN_ID stamp); falls back to this
+                                // WorkRequest's own WorkManager-assigned id for standalone tasks,
+                                // matching ExecutionRecord.chainId's documented "or auto-generated"
+                                // fallback. NOTE: unlike iOS's ChainExecutor, which writes one
+                                // aggregate record per chain, Android's WorkManager runs each chain
+                                // step through this class independently — so a multi-step chain on
+                                // Android produces one ExecutionRecord per step, all sharing the
+                                // same chainId, rather than a single record for the whole chain.
+                                chainId = chainId ?: id.toString(),
                                 status = historyStatus!!,
                                 startedAtMs = startTime,
                                 endedAtMs = nowMs,
                                 durationMs = historyDuration,
-                                totalSteps = 1,
+                                totalSteps = totalSteps ?: 1,
                                 completedSteps = if (historyStatus == ExecutionStatus.SUCCESS) 1 else 0,
-                                failedStep = if (historyStatus != ExecutionStatus.SUCCESS) 0 else null,
+                                failedStep = if (historyStatus != ExecutionStatus.SUCCESS) (stepIndex ?: 0) else null,
                                 errorMessage = null,
                                 retryCount = runAttemptCount,
                                 platform = "android",

--- a/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -41,6 +41,15 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         // Retry ceiling stamped from Constraints.maxRetries and read back by BaseKmpWorker.
         // Absent → treated as -1 (uncapped). WorkManager has no native max-retry API.
         const val KEY_MAX_RETRIES = "maxRetries"
+        // Chain identity, stamped per-step by enqueueChain()/createWorkRequest() and read back
+        // by BaseKmpWorker to populate TelemetryHook events and ExecutionRecord. Namespaced
+        // (kmp_ prefix) rather than a bare name like "chainId" because WorkContinuation.then()
+        // merges a prerequisite step's outputData into the next step's inputData via the default
+        // OverwritingInputMerger — a user worker whose own outputData happened to use a bare key
+        // would silently clobber this stamp for step 2+.
+        const val KEY_CHAIN_ID = "kmp_chain_id"
+        const val KEY_STEP_INDEX = "kmp_step_index"
+        const val KEY_TOTAL_STEPS = "kmp_total_steps"
         internal const val OVERFLOW_THRESHOLD_BYTES = 8192 // 8 KB
         private const val ZOMBIE_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000L // 24 hours
         private val cleanupStarted = java.util.concurrent.atomic.AtomicBoolean(false)
@@ -341,9 +350,12 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         inputJson: String?,
         taskType: String,
         initialDelayMs: Long,
-        wmConstraints: androidx.work.Constraints
+        wmConstraints: androidx.work.Constraints,
+        chainId: String? = null,
+        stepIndex: Int? = null,
+        totalSteps: Int? = null
     ): OneTimeWorkRequest {
-        val workData = buildWorkData(id, workerClassName, inputJson, constraints.maxRetries)
+        val workData = buildWorkData(id, workerClassName, inputJson, constraints.maxRetries, chainId, stepIndex, totalSteps)
         val builder = if (constraints.isHeavyTask) {
             OneTimeWorkRequestBuilder<KmpHeavyWorker>()
         } else {
@@ -374,10 +386,21 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         return builder.build()
     }
 
-    private fun buildWorkData(taskId: String, workerClassName: String, inputJson: String?, maxRetries: Int): Data {
+    private fun buildWorkData(
+        taskId: String,
+        workerClassName: String,
+        inputJson: String?,
+        maxRetries: Int,
+        chainId: String? = null,
+        stepIndex: Int? = null,
+        totalSteps: Int? = null
+    ): Data {
         val builder = Data.Builder().putString("workerClassName", workerClassName)
         // Stamp the retry ceiling before any early return so null-input tasks are capped too.
         if (maxRetries >= 0) builder.putInt(KEY_MAX_RETRIES, maxRetries)
+        if (chainId != null) builder.putString(KEY_CHAIN_ID, chainId)
+        if (stepIndex != null) builder.putInt(KEY_STEP_INDEX, stepIndex)
+        if (totalSteps != null) builder.putInt(KEY_TOTAL_STEPS, totalSteps)
         if (inputJson == null) return builder.build()
 
         val bytes = inputJson.encodeToByteArray()
@@ -501,20 +524,32 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         if (steps.isEmpty()) return
 
         val chainId = id ?: java.util.UUID.randomUUID().toString()
+        val totalSteps = steps.size
         val wmPolicy = when (policy) {
             ExistingPolicy.REPLACE -> ExistingWorkPolicy.REPLACE
             ExistingPolicy.KEEP -> ExistingWorkPolicy.KEEP
         }
 
-        var continuation = workManager.beginUniqueWork(chainId, wmPolicy, steps.first().map { createWorkRequest(it) })
-        steps.drop(1).forEach { step ->
-            continuation = continuation.then(step.map { createWorkRequest(it) })
+        // Stamp chainId/stepIndex/totalSteps into every step's inputData so BaseKmpWorker can
+        // recover chain identity for TelemetryHook events and ExecutionRecord — WorkManager's
+        // native then()-chaining carries no chain metadata of its own (only a per-step tag).
+        var continuation = workManager.beginUniqueWork(
+            chainId, wmPolicy, steps.first().map { createWorkRequest(it, chainId, 0, totalSteps) }
+        )
+        steps.drop(1).forEachIndexed { offset, step ->
+            val stepIndex = offset + 1
+            continuation = continuation.then(step.map { createWorkRequest(it, chainId, stepIndex, totalSteps) })
         }
         continuation.enqueue()
     }
 
     @OptIn(AndroidOnly::class)
-    private fun createWorkRequest(task: TaskRequest): OneTimeWorkRequest {
+    private fun createWorkRequest(
+        task: TaskRequest,
+        chainId: String? = null,
+        stepIndex: Int? = null,
+        totalSteps: Int? = null
+    ): OneTimeWorkRequest {
         val wmConstraints = buildWorkManagerConstraints(task.constraints ?: Constraints())
         return buildOneTimeWorkRequest(
             java.util.UUID.randomUUID().toString(),
@@ -523,7 +558,10 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
             task.inputJson,
             "chain",
             0L,
-            wmConstraints
+            wmConstraints,
+            chainId,
+            stepIndex,
+            totalSteps
         )
     }
 

--- a/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V340ChainIdentityTelemetryTest.kt
+++ b/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V340ChainIdentityTelemetryTest.kt
@@ -1,0 +1,194 @@
+package dev.brewkits.kmpworkmanager.background.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Data
+import androidx.work.ListenableWorker.Result
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import dev.brewkits.kmpworkmanager.KmpWorkManagerRuntime
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorker
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorkerFactory
+import dev.brewkits.kmpworkmanager.background.domain.ExecutionRecord
+import dev.brewkits.kmpworkmanager.background.domain.ExecutionStatus
+import dev.brewkits.kmpworkmanager.background.domain.TelemetryHook
+import dev.brewkits.kmpworkmanager.background.domain.WorkerEnvironment
+import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
+import dev.brewkits.kmpworkmanager.persistence.ExecutionHistoryStore
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression net for a chain-identity telemetry bug found by manually running the demo app
+ * and reading its logs (per the pre-3.4.0 publish review): [BaseKmpWorker] never passed
+ * `chainId`/`stepIndex` to [TelemetryHook] events, and stamped [ExecutionRecord.chainId] with
+ * WorkManager's own per-request UUID instead of the ID passed to `TaskChain.withId()` — every
+ * `TaskStartedEvent` logged `chain=null step=null` even for genuine chain-member tasks.
+ *
+ * Root cause: WorkManager's native `then()`-chaining carries no chain metadata of its own
+ * (`enqueueChain()`'s `taskType = "chain"` was only ever used for a debug tag). The fix stamps
+ * `NativeTaskScheduler.KEY_CHAIN_ID` / `KEY_STEP_INDEX` / `KEY_TOTAL_STEPS` into each chain
+ * step's `inputData`, and `BaseKmpWorker` reads them back for both telemetry and history.
+ *
+ * Unlike iOS's `ChainExecutor` (one aggregate [ExecutionRecord] per chain), Android still writes
+ * one record per step — see the divergence note on [ExecutionRecord]'s KDoc. This test pins the
+ * per-step contract: chain-member records share the real chainId and the chain's totalSteps,
+ * standalone-task records keep the pre-existing fallback behavior unchanged.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class V340ChainIdentityTelemetryTest {
+
+    private lateinit var context: Context
+    private val capturedStarted = mutableListOf<TelemetryHook.TaskStartedEvent>()
+    private val capturedCompleted = mutableListOf<TelemetryHook.TaskCompletedEvent>()
+    private val capturedFailed = mutableListOf<TelemetryHook.TaskFailedEvent>()
+    private val savedRecords = mutableListOf<ExecutionRecord>()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        capturedStarted.clear()
+        capturedCompleted.clear()
+        capturedFailed.clear()
+        savedRecords.clear()
+
+        KmpWorkManagerRuntime.telemetryHook = object : TelemetryHook {
+            override fun onTaskStarted(event: TelemetryHook.TaskStartedEvent) { capturedStarted += event }
+            override fun onTaskCompleted(event: TelemetryHook.TaskCompletedEvent) { capturedCompleted += event }
+            override fun onTaskFailed(event: TelemetryHook.TaskFailedEvent) { capturedFailed += event }
+        }
+        KmpWorkManagerRuntime.executionHistoryStore = object : ExecutionHistoryStore {
+            override suspend fun save(record: ExecutionRecord) { savedRecords += record }
+            override suspend fun getRecords(limit: Int): List<ExecutionRecord> = savedRecords.toList()
+            override suspend fun clear() { savedRecords.clear() }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        KmpWorkManagerRuntime.telemetryHook = null
+        KmpWorkManagerRuntime.executionHistoryStore = null
+    }
+
+    @Test
+    fun chainStep_stampsRealChainIdAndStepIndex_intoTaskStartedEvent() {
+        runWorker(WorkerResult.Success(), chainId = "my-real-chain-id", stepIndex = 1, totalSteps = 3)
+
+        val started = capturedStarted.single()
+        assertEquals("my-real-chain-id", started.chainId, "TaskStartedEvent.chainId must be the real chain ID, not null.")
+        assertEquals(1, started.stepIndex, "TaskStartedEvent.stepIndex must be the real 0-based step index.")
+    }
+
+    @Test
+    fun chainStep_stampsChainIdAndStepIndex_intoCompletedAndFailedEvents() {
+        runWorker(WorkerResult.Success(), chainId = "chain-a", stepIndex = 2, totalSteps = 4)
+        val completed = capturedCompleted.single()
+        assertEquals("chain-a", completed.chainId)
+        assertEquals(2, completed.stepIndex)
+
+        runWorker(WorkerResult.Failure("boom", shouldRetry = false), chainId = "chain-b", stepIndex = 0, totalSteps = 2)
+        val failed = capturedFailed.single()
+        assertEquals("chain-b", failed.chainId)
+        assertEquals(0, failed.stepIndex)
+    }
+
+    @Test
+    fun chainStep_executionRecord_usesRealChainId_notWorkRequestUuid() {
+        runWorker(WorkerResult.Success(), chainId = "user-supplied-chain-id", stepIndex = 0, totalSteps = 2)
+
+        val record = savedRecords.single()
+        assertEquals(
+            "user-supplied-chain-id", record.chainId,
+            "ExecutionRecord.chainId must match TaskChain.withId(), not a WorkManager-internal UUID."
+        )
+        assertEquals(2, record.totalSteps, "ExecutionRecord.totalSteps must reflect the chain's real step count.")
+    }
+
+    @Test
+    fun chainStep_failure_executionRecord_failedStepMatchesRealStepIndex() {
+        runWorker(WorkerResult.Failure("boom", shouldRetry = false), chainId = "chain-c", stepIndex = 2, totalSteps = 3)
+
+        val record = savedRecords.single()
+        assertEquals(ExecutionStatus.ABANDONED, record.status)
+        assertEquals(2, record.failedStep, "failedStep must be the real step index that failed, not always 0.")
+    }
+
+    @Test
+    fun standaloneTask_chainIdAndStepIndex_stayNull_notFalselyStamped() {
+        runWorker(WorkerResult.Success(), chainId = null, stepIndex = null, totalSteps = null)
+
+        val started = capturedStarted.single()
+        assertNull(started.chainId, "A standalone (non-chain) task must never report a fabricated chainId.")
+        assertNull(started.stepIndex)
+    }
+
+    @Test
+    fun standaloneTask_executionRecord_fallsBackToWorkRequestId_backCompat() {
+        runWorker(WorkerResult.Success(), chainId = null, stepIndex = null, totalSteps = null)
+
+        val record = savedRecords.single()
+        assertTrue(record.chainId.isNotBlank(), "Standalone tasks must keep the pre-existing auto-generated chainId fallback.")
+        assertEquals(1, record.totalSteps, "Standalone tasks must keep totalSteps=1, unaffected by the chain fix.")
+    }
+
+    private fun runWorker(
+        result: WorkerResult,
+        chainId: String?,
+        stepIndex: Int?,
+        totalSteps: Int?
+    ) {
+        ChainIdentityTestWorker.factoryHolder = AndroidWorkerFactory_ChainIdentity(result)
+
+        val inputBuilder = Data.Builder().putString("workerClassName", "SomeWorker")
+        if (chainId != null) inputBuilder.putString(NativeTaskScheduler.KEY_CHAIN_ID, chainId)
+        if (stepIndex != null) inputBuilder.putInt(NativeTaskScheduler.KEY_STEP_INDEX, stepIndex)
+        if (totalSteps != null) inputBuilder.putInt(NativeTaskScheduler.KEY_TOTAL_STEPS, totalSteps)
+
+        val worker = TestListenableWorkerBuilder<ChainIdentityTestWorker>(context)
+            .setInputData(inputBuilder.build())
+            .build()
+        val outcome = runBlocking { worker.doWork() }
+        // Sanity: the harness itself must reach the branch under test (not fail earlier for
+        // unrelated reasons), otherwise the assertions above would trivially pass on empty lists.
+        assertTrue(outcome is Result.Success || outcome is Result.Failure, "Unexpected worker outcome: $outcome")
+    }
+}
+
+private class AndroidWorkerFactory_ChainIdentity(private val result: WorkerResult) : AndroidWorkerFactory {
+    override fun createWorker(workerClassName: String): AndroidWorker = object : AndroidWorker {
+        override suspend fun doWork(input: String?, env: WorkerEnvironment): WorkerResult = result
+    }
+}
+
+class ChainIdentityTestWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : BaseKmpWorker(appContext, workerParams, factoryHolder!!) {
+
+    override val workerLogTag: String get() = "ChainIdentityTestWorker"
+    override suspend fun doWork(): Result = doWorkInternal()
+    override suspend fun performWork(workerClassName: String, inputJson: String?): WorkerResult {
+        val worker = workerFactory.createWorker(workerClassName)
+            ?: return WorkerResult.Failure("not found")
+        return worker.doWork(inputJson, WorkerEnvironment(
+            progressListener = object : dev.brewkits.kmpworkmanager.background.domain.ProgressListener {
+                override fun onProgressUpdate(progress: dev.brewkits.kmpworkmanager.background.domain.WorkerProgress) {}
+            },
+            isCancelled = { false }
+        ))
+    }
+
+    companion object {
+        @Volatile
+        var factoryHolder: AndroidWorkerFactory? = null
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/ExecutionRecord.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/ExecutionRecord.kt
@@ -3,11 +3,19 @@ package dev.brewkits.kmpworkmanager.background.domain
 import kotlinx.serialization.Serializable
 
 /**
- * A single persisted record of a background task chain execution.
+ * A single persisted record of a background task or chain-step execution.
  *
- * Records are written when a chain finishes (success, failure, abandoned, skipped)
+ * Records are written when a task finishes (success, failure, abandoned, skipped)
  * and stored locally via [ExecutionHistoryStore]. Call [BackgroundTaskScheduler.getExecutionHistory]
  * to retrieve them and upload to your server when the app is foregrounded.
+ *
+ * **Platform divergence:** on iOS, [ChainExecutor] writes ONE aggregate record per chain
+ * (`totalSteps` = the chain's full step count, written once the chain finishes). On Android,
+ * WorkManager runs each chain step through an independent `Worker`, so a multi-step chain
+ * produces ONE [ExecutionRecord] PER STEP, all sharing the same [chainId] — `totalSteps` on
+ * each of those records reflects the chain's total step count, not "1 record = 1 step".
+ * Group by [chainId] and use [completedSteps]/`workerClassNames.size` if you need per-chain
+ * rollups on Android.
  *
  * ```kotlin
  * // Collect on app foreground, upload to backend


### PR DESCRIPTION
## Bug

Found by manually running the composeApp demo's Sequential chain and reading its logs (per the pre-Maven-publish review pass): every `TaskStartedEvent` logged `chain=null step=null`, even for genuine chain-member tasks that were executing correctly.

**Root cause:** WorkManager's native `beginUniqueWork().then()` chaining carries no chain metadata of its own. `enqueueChain()`'s `taskType = "chain"` string was only ever used for a WorkManager debug tag (`addTag("type-$taskType")`), never persisted into a step's `inputData`. `BaseKmpWorker` had nothing to read back — unlike iOS's `ChainExecutor`, which has always passed `chainId`/`stepIndex` correctly.

**Related bug also fixed:** `ExecutionRecord.chainId` on Android was populated with `ListenableWorker.id` (WorkManager's per-request random UUID) instead of the ID passed to `TaskChain.withId()`, contradicting the field's own documented contract ("Matches the ID passed to `TaskChain.withId()`, or auto-generated").

## Fix

`enqueueChain()` now stamps namespaced `kmp_chain_id` / `kmp_step_index` / `kmp_total_steps` keys into each step's `inputData`. Namespaced (not bare names like `chainId`) because `WorkContinuation.then()`'s default `OverwritingInputMerger` could otherwise let a user worker's own `outputData` clobber these for step 2+.

`BaseKmpWorker` reads them back and threads them through `TaskStartedEvent`/`TaskCompletedEvent`/`TaskFailedEvent` and `ExecutionRecord`.

Standalone (non-chain) tasks are unaffected — `chainId`/`stepIndex` stay `null`, `ExecutionRecord` keeps its pre-existing auto-generated-id fallback (regression-tested).

## Scope note (deliberately not attempted here)

Android still writes **one `ExecutionRecord` per chain step** (all sharing the real `chainId`), while iOS's `ChainExecutor` writes **one aggregate record per whole chain**. This is a pre-existing, orthogonal platform divergence — documented explicitly in `ExecutionRecord`'s KDoc rather than silently left unstated. True per-chain aggregation on Android would require knowing "last step completed" from inside a `Worker`, which WorkManager doesn't expose; that's a separate, larger project, not folded into this correctness fix.

## Testing

- 6 new Robolectric tests (`V340ChainIdentityTelemetryTest`), all passing.
- Full `:kmpworker:testDebugUnitTest` green.
- Full `:kmpworker:allTests` (Android + iOS) green — 205 test-result files, 0 failures/errors.