### PR TITLE
feat: WorkManager parity — task tags, deadlines, InputMerger, UPDATE policy (v3.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,49 @@ All notable changes to KMP WorkManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.0] - 2026-09-01
+## [3.5.0] - 2026-09-02
+
+Jetpack WorkManager parity pass: four features that native WorkManager users expect and
+had no equivalent here, implemented on **both** platforms rather than Android-only.
 
 ### Added
+
+- **`TaskRequest.tags` + `scheduler.cancelByTag(tag)` / `cancelByWorkerClass(name)`** —
+  group cancellation. Tags are business-context labels independent of worker class, so a
+  single call can cancel a mixed set of workers (`cancelByTag("user-123")`). Both APIs match
+  standalone tasks *and* chain steps on both platforms; `enqueue()` gained a `tags` parameter
+  so standalone tasks are reachable too. Tags are validated at construction (non-blank, no
+  commas, ≤100 chars) because an unstorable tag would make cancellation silently no-op.
+  **Not supported for `TaskTrigger.Exact` on Android** (AlarmManager is not tag-indexed) —
+  a warning is logged rather than failing silently.
+- **`TaskRequest.deadlineMs` + `enqueue(deadlineMs = …)`** — a task that has not started by
+  its deadline is skipped instead of executed, so a delayed run cannot write stale data.
+  Enforced at execution time on both platforms (Android `BaseKmpWorker`, iOS
+  `DynamicTaskDispatcher` and `ChainExecutor`). A miss is recorded as
+  `ExecutionStatus.SKIPPED` and never retried — retrying cannot un-miss a deadline. On iOS
+  this finally gives `TaskTrigger.Windowed.latest` real teeth: it now defaults to the
+  deadline, where previously BGTaskScheduler could only log that it was unenforceable.
+  Deliberately ignored for periodic tasks (a deadline on a recurring task is a delayed
+  cancel, not a deadline) — a warning is logged.
+- **`TaskRequest.mergeOutputFromPreviousStep`** — the InputMerger. A chain step can opt in to
+  receiving the previous step's `WorkerResult.Success.data` merged into its own `inputJson`,
+  removing the need for an external store to pass data along a
+  `download → validate → upload` pipeline. Overwriting-merge semantics (previous step wins on
+  key collision), matching WorkManager's default `OverwritingInputMerger`, with one shared
+  implementation (`ChainInputMerger`) used by both platforms so the behaviour cannot drift.
+- **`ExistingPolicy.UPDATE`** — updates a periodic task's constraints/input **without**
+  resetting its interval timer. Maps to `ExistingPeriodicWorkPolicy.UPDATE` on Android; on
+  iOS the existing `anchoredStartMs` is preserved so drift correction keeps the original
+  cadence. Degrades to `REPLACE` for one-time tasks and chains, which have no timer anchor.
+
+### Changed
+
+- `BackgroundTaskScheduler.enqueue()` gained `tags` and `deadlineMs` parameters (both
+  defaulted). **Source-compatible for callers**; classes that *override* `enqueue` must add
+  the two parameters. `cancelByTag`/`cancelByWorkerClass` ship with no-op default
+  implementations specifically so existing custom schedulers and test doubles keep compiling.
+- `FakeBackgroundTaskScheduler` (test utility) now records `tags`, `deadlineMs`,
+  `cancelledTags` and `cancelledWorkerClasses` so tests can assert on the new APIs.
 
 - **`kmpworkmanager-http`: HMAC-SHA256 request signing + token refresh on 401.**
   `HttpRequestConfig` gains optional `hmacSigning: HmacSigningConfig` (canonical string

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 ```kotlin
 // build.gradle.kts
 commonMain.dependencies {
-    implementation("dev.brewkits:kmpworkmanager:3.3.0")          // core engine (no Ktor)
+    implementation("dev.brewkits:kmpworkmanager:3.5.0")          // core engine (no Ktor)
     // Optional — only if you use the built-in HTTP workers (Http*/ParallelHttp*).
-    implementation("dev.brewkits:kmpworkmanager-http:3.3.0")     // Ktor 3 HTTP workers
+    implementation("dev.brewkits:kmpworkmanager-http:3.5.0")     // Ktor 3 HTTP workers
 }
 ```
 
@@ -178,6 +178,65 @@ scheduler.beginWith(TaskRequest("DownloadWorker", inputJson = """{"url":"$fileUr
     .enqueue()
 ```
 
+### Pass data between chain steps
+
+Set `mergeOutputFromPreviousStep = true` and a step receives the previous step's
+`WorkerResult.Success.data` merged into its own `inputJson` — no external store needed.
+On a key collision the previous step's value wins, matching WorkManager's default
+`OverwritingInputMerger`. Both platforms behave identically.
+
+```kotlin
+scheduler.beginWith(TaskRequest("DownloadWorker", inputJson = """{"url":"$fileUrl"}"""))
+    // DownloadWorker returns Success(data = {"filePath": "/tmp/x.zip"})
+    .then(TaskRequest("ValidateWorker", mergeOutputFromPreviousStep = true))  // sees filePath
+    .then(TaskRequest("UploadWorker", mergeOutputFromPreviousStep = true))    // sees filePath
+    .enqueue()
+```
+
+### Cancel a group of tasks
+
+Tags are business-context labels, independent of worker class — one call cancels a mixed
+set of workers. Works for standalone tasks and chain steps alike.
+
+```kotlin
+scheduler.enqueue(
+    id = "sync-profile",
+    trigger = TaskTrigger.OneTime(),
+    workerClassName = "SyncWorker",
+    tags = setOf("user-123"),
+)
+scheduler.beginWith(TaskRequest("UploadWorker", tags = setOf("user-123"))).enqueue()
+
+// Cancels both, whatever worker they use:
+scheduler.cancelByTag("user-123")
+
+// Or cancel every task of one worker type:
+scheduler.cancelByWorkerClass("SyncWorker")
+```
+
+> `cancelByTag` does not cover `TaskTrigger.Exact` on Android — exact alarms run through
+> `AlarmManager`, which is not tag-indexed. Cancel those by id.
+
+### Skip work that has gone stale
+
+`deadlineMs` marks the point after which running the task is worse than not running it.
+A task that has not started by then is skipped (recorded as `ExecutionStatus.SKIPPED`)
+and never retried — retrying cannot un-miss a deadline. A skipped step does not abort the
+rest of its chain.
+
+```kotlin
+scheduler.enqueue(
+    id = "pre-flight-sync",
+    trigger = TaskTrigger.OneTime(),
+    workerClassName = "SyncWorker",
+    deadlineMs = departureTimeMs,  // pointless to sync after the flight leaves
+)
+```
+
+This is what finally makes `TaskTrigger.Windowed(earliest, latest)` enforceable on iOS:
+`latest` is now honoured as a deadline at execution time, where BGTaskScheduler itself
+offers no ceiling.
+
 ---
 
 ## Why KMP WorkManager?
@@ -208,6 +267,20 @@ and no recovery mechanism for incomplete work. Getting it wrong means your tasks
 | `ContentUri(uri)` | WorkManager ContentUriTrigger | — | Android only |
 
 ---
+
+## What's new in v3.5.0
+
+**Jetpack WorkManager parity.** Four features native WorkManager users expect, now on both
+platforms: **task tags + group cancellation** (`cancelByTag` / `cancelByWorkerClass`),
+**per-task deadlines** (`deadlineMs` — skip rather than run stale work), the **chain
+InputMerger** (`mergeOutputFromPreviousStep` — pass a step's output into the next step's
+input), and **`ExistingPolicy.UPDATE`** (change a periodic task's constraints without
+resetting its interval timer). See the sections above for usage.
+
+Adding `cancelByTag`/`cancelByWorkerClass` to `BackgroundTaskScheduler` is source-compatible
+— both ship with no-op default implementations so existing custom schedulers and test doubles
+keep compiling. Classes that *override* `enqueue()` must add the new `tags` and `deadlineMs`
+parameters.
 
 ## What's new in v3.2.0
 

--- a/composeApp/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/sample/FakeBackgroundTaskScheduler.kt
+++ b/composeApp/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/sample/FakeBackgroundTaskScheduler.kt
@@ -16,7 +16,9 @@ class FakeBackgroundTaskScheduler : BackgroundTaskScheduler {
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String>,
+        deadlineMs: Long?
     ): ScheduleResult {
         println("FakeBackgroundTaskScheduler: Enqueue called for $id")
         return ScheduleResult.ACCEPTED
@@ -28,6 +30,14 @@ class FakeBackgroundTaskScheduler : BackgroundTaskScheduler {
 
     override fun cancelAll() {
         println("FakeBackgroundTaskScheduler: CancelAll called")
+    }
+
+    override fun cancelByTag(tag: String) {
+        println("FakeBackgroundTaskScheduler: cancelByTag called for '$tag'")
+    }
+
+    override fun cancelByWorkerClass(workerClassName: String) {
+        println("FakeBackgroundTaskScheduler: cancelByWorkerClass called for '$workerClassName'")
     }
 
     override fun beginWith(task: TaskRequest): TaskChain {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,42 @@ Status legend: ✅ done · 🚧 in progress · ⏳ planned · 💭 idea / unsche
 
 ---
 
+## v3.5.0 — Jetpack WorkManager parity — ✅ shipped
+
+Four features native WorkManager users expect, implemented on **both** platforms:
+
+- ✅ **Task tags + group cancellation** — `TaskRequest.tags`, `enqueue(tags = …)`,
+  `cancelByTag()`, `cancelByWorkerClass()`. Covers standalone tasks and chain steps.
+  Not available for `TaskTrigger.Exact` on Android (AlarmManager is not tag-indexed).
+- ✅ **Per-task deadlines** — `TaskRequest.deadlineMs` / `enqueue(deadlineMs = …)`.
+  A task past its deadline is skipped, not run, and never retried. Gives
+  `TaskTrigger.Windowed.latest` real enforcement on iOS for the first time.
+- ✅ **Chain InputMerger** — `TaskRequest.mergeOutputFromPreviousStep`. Overwriting-merge
+  semantics matching WorkManager's `OverwritingInputMerger`, via one shared
+  `ChainInputMerger` so the two engines cannot drift.
+- ✅ **`ExistingPolicy.UPDATE`** — update a periodic task's constraints/input without
+  resetting its interval timer.
+
+Still open from the same parity analysis, in rough priority order:
+
+- ⏳ **`observeTaskState(id): Flow<TaskState>`** — live state stream, replacing
+  poll-`getExecutionHistory()`. Android: wrap `getWorkInfosForUniqueWorkFlow` (note:
+  WorkManager indexes by UUID, so this must go through the unique-name API, not
+  `getWorkInfoByIdFlow`). iOS: a `StateFlow` registry updated by `ChainExecutor` /
+  `SingleTaskExecutor` transitions.
+- ⏳ **`WorkQuery`-style batch query** — filter pending/running tasks by state/tag/worker.
+  Read-only on both platforms; iOS needs a scan across queue + metadata + active chains.
+- ⏳ **`ExistingPolicy.APPEND`** — append steps to a chain that is already queued or
+  running. iOS is the hard part: load-modify-save `ChainProgress` under a mutex while
+  `ChainExecutor` may be mid-chain. (The `when` over `ExistingPolicy` in iOS
+  `enqueueChain` is deliberately exhaustive so adding this forces a decision there.)
+- 💭 **`setNextScheduleTimeOverride()`** — **not feasible on iOS.** BGTaskScheduler offers
+  no way to override a registered task's next run; only cancel + reschedule, which is
+  what `cancel()` + `enqueue()` already do. Android-only, so it fails the
+  "both platforms or it isn't parity" bar below.
+
+---
+
 ## Next up (post-3.3.1) — the "irreplaceable, even for native-only teams" bar
 
 **Theme:** every milestone through 3.3.1 below made the library more correct or

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,9 +33,32 @@ Still open from the same parity analysis, in rough priority order:
 - ⏳ **`WorkQuery`-style batch query** — filter pending/running tasks by state/tag/worker.
   Read-only on both platforms; iOS needs a scan across queue + metadata + active chains.
 - ⏳ **`ExistingPolicy.APPEND`** — append steps to a chain that is already queued or
-  running. iOS is the hard part: load-modify-save `ChainProgress` under a mutex while
-  `ChainExecutor` may be mid-chain. (The `when` over `ExistingPolicy` in iOS
-  `enqueueChain` is deliberately exhaustive so adding this forces a decision there.)
+  running. Android maps to `ExistingWorkPolicy.APPEND`/`APPEND_OR_REPLACE` directly; iOS
+  needs real design work, and **an earlier analysis of this got it wrong in a way worth
+  recording**:
+
+  > *Claim:* "`ChainExecutor` re-reads `loadChainDefinition()` fresh from disk before each
+  > step, so appending to the end is race-free."
+  >
+  > *Reality (verified in code):* `executeChain` calls `loadChainDefinition` **once**
+  > (~line 748) and then iterates the resulting in-memory list (~line 925) — both inside
+  > the same function. Nothing re-reads the definition per step.
+
+  Consequences the design must handle, none of which the "just append" approach covers:
+  - Appending to a **running** chain writes to disk that the in-flight executor never
+    re-reads, so the new steps are silently dropped for that invocation.
+  - `executeChain` **deletes the chain definition on completion** (~line 1153), so
+    appending to a chain that just finished writes into a file about to vanish, or
+    resurrects a deleted one, depending on timing.
+  - `ChainProgress` records completed-step indices; appending must not renumber existing
+    steps or a resumed chain will re-run or skip work.
+
+  A workable shape is probably: re-read the definition at the top of each step iteration
+  under the chain's existing lock, plus an explicit rule for "append to a chain that is
+  finishing" (reject, or convert to a new chain). Not a small change — treat it as its own
+  milestone, not a quick win. (The `when` over `ExistingPolicy` in iOS `enqueueChain` is
+  deliberately exhaustive so adding this forces a decision there rather than silently
+  falling through to the KEEP branch.)
 - 💭 **`setNextScheduleTimeOverride()`** — **not feasible on iOS.** BGTaskScheduler offers
   no way to override a registered task's next run; only cancel + reschedule, which is
   what `cancel()` + `enqueue()` already do. Android-only, so it fails the

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.4.0
+VERSION_NAME=3.5.0
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=false

--- a/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/BaseKmpWorker.kt
+++ b/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/BaseKmpWorker.kt
@@ -3,6 +3,7 @@ package dev.brewkits.kmpworkmanager.background.data
 import android.content.Context
 import android.os.BatteryManager
 import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.WorkerParameters
 import dev.brewkits.kmpworkmanager.KmpWorkManagerAndroid
 import dev.brewkits.kmpworkmanager.KmpWorkManagerRuntime
@@ -12,6 +13,8 @@ import dev.brewkits.kmpworkmanager.utils.LogTags
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Base class for [KmpWorker] and [KmpHeavyWorker].
@@ -101,6 +104,41 @@ abstract class BaseKmpWorker : CoroutineWorker {
 
     protected abstract suspend fun performWork(workerClassName: String, inputJson: String?): WorkerResult
 
+    /**
+     * Serialises a worker's [WorkerResult.Success.data] into the output [Data] that
+     * WorkManager hands to the next chain step (see [NativeTaskScheduler.KEY_STEP_OUTPUT]).
+     *
+     * Returns [Data.EMPTY] when there is nothing to forward, or when the payload exceeds
+     * WorkManager's Data budget. **Oversized output is dropped, not spilled to disk:** the
+     * overflow-file mechanism used for *input* is keyed to a task id that can be cleaned up
+     * on cancel, whereas an output file would have no owner if the successor never runs.
+     * Dropping degrades InputMerger to "no data forwarded" — the successor still executes
+     * with its own input — instead of failing a step that actually succeeded.
+     */
+    private fun buildStepOutputData(data: JsonObject?): Data {
+        if (data == null || data.isEmpty()) return Data.EMPTY
+        return try {
+            val encoded = Json.encodeToString(JsonObject.serializer(), data)
+            // WorkManager rejects Data over 10 KB at build time; stay under the same 8 KB
+            // threshold the input path uses so a chain can't fail on the return trip.
+            if (encoded.encodeToByteArray().size > NativeTaskScheduler.OVERFLOW_THRESHOLD_BYTES) {
+                Logger.w(
+                    LogTags.WORKER,
+                    "$workerLogTag output too large to forward to the next chain step " +
+                        "(${encoded.encodeToByteArray().size} bytes > ${NativeTaskScheduler.OVERFLOW_THRESHOLD_BYTES}). " +
+                        "InputMerger will see no data. Pass large payloads by reference (file path / row id) instead."
+                )
+                Data.EMPTY
+            } else {
+                Data.Builder().putString(NativeTaskScheduler.KEY_STEP_OUTPUT, encoded).build()
+            }
+        } catch (e: Exception) {
+            // Never fail a successful worker because its output could not be serialised.
+            Logger.w(LogTags.WORKER, "$workerLogTag failed to serialise output for InputMerger: ${e.message}")
+            Data.EMPTY
+        }
+    }
+
     protected suspend fun doWorkInternal(): Result {
         val workerClassName = inputData.getString("workerClassName")
             ?: return Result.failure()
@@ -128,7 +166,58 @@ abstract class BaseKmpWorker : CoroutineWorker {
         )
 
         try {
-            val inputJson = resolveInputJson()
+            val resolvedInputJson = resolveInputJson()
+
+            // InputMerger (P1-D): when this step opted in via TaskRequest.mergeOutputFromPreviousStep,
+            // the prerequisite step's WorkerResult.Success.data has been carried here by
+            // WorkManager's default OverwritingInputMerger under KEY_STEP_OUTPUT. Merge it into
+            // the task's own inputJson using the shared ChainInputMerger so the result is
+            // byte-identical to what iOS's ChainExecutor produces for the same pair of values.
+            //
+            // Absent output (previous worker returned data = null, or this is the first step)
+            // leaves inputJson untouched rather than blanking it.
+            val inputJson = if (inputData.getBoolean(NativeTaskScheduler.KEY_MERGE_PREVIOUS_OUTPUT, false)) {
+                val previousOutputRaw = inputData.getString(NativeTaskScheduler.KEY_STEP_OUTPUT)
+                val previousOutput = ChainInputMerger.parseObjectOrEmpty(previousOutputRaw)
+                if (previousOutput.isEmpty()) {
+                    Logger.d(
+                        LogTags.WORKER,
+                        "$workerLogTag mergeOutputFromPreviousStep=true but previous step produced no output — using original input"
+                    )
+                    resolvedInputJson
+                } else {
+                    ChainInputMerger.merge(resolvedInputJson, JsonObject(previousOutput)).also {
+                        Logger.d(
+                            LogTags.WORKER,
+                            "$workerLogTag merged ${previousOutput.size} field(s) from previous step into input"
+                        )
+                    }
+                }
+            } else {
+                resolvedInputJson
+            }
+
+            // Deadline guard (P1-C): skip stale tasks before they execute.
+            // Result.success() (not failure) avoids WorkManager retry loops —
+            // a deadline miss is not a worker error; the task is intentionally discarded.
+            val deadlineMs = inputData.getLong(NativeTaskScheduler.KEY_DEADLINE_MS, -1L)
+                .takeIf { it > 0L }
+            if (deadlineMs != null && System.currentTimeMillis() > deadlineMs) {
+                Logger.w(
+                    LogTags.WORKER,
+                    "⏰ $workerLogTag SKIPPED: $workerClassName deadline exceeded " +
+                        "(deadline=${deadlineMs}ms, now=${System.currentTimeMillis()}ms)"
+                )
+                TaskEventManager.emit(
+                    TaskCompletionEvent(
+                        taskName = workerClassName,
+                        success = false,
+                        message = "Deadline exceeded — task skipped"
+                    )
+                )
+                historyStatus = ExecutionStatus.SKIPPED
+                return Result.success()  // Don't retry; the deadline window is gone
+            }
 
             if (checkBatteryGuard()) {
                 isRetrying = true
@@ -164,7 +253,14 @@ abstract class BaseKmpWorker : CoroutineWorker {
                         )
                     )
                     historyStatus = ExecutionStatus.SUCCESS
-                    return Result.success()
+                    // InputMerger (P1-D): publish this worker's output so the NEXT chain step can
+                    // consume it. WorkManager's default OverwritingInputMerger copies a
+                    // prerequisite's output Data into its successor's input Data, which is the
+                    // only channel available here — a Worker cannot address the next node directly.
+                    // Emitted unconditionally on success (not gated on the *next* step's opt-in,
+                    // which this worker cannot see); the successor ignores it unless it set
+                    // mergeOutputFromPreviousStep. Standalone tasks simply have no successor.
+                    return Result.success(buildStepOutputData(result.data))
                 }
                 is WorkerResult.Failure -> {
                     Logger.w(LogTags.WORKER, "$workerLogTag failure: $workerClassName — ${result.message}")

--- a/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/androidMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -43,13 +43,27 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         const val KEY_MAX_RETRIES = "maxRetries"
         // Chain identity, stamped per-step by enqueueChain()/createWorkRequest() and read back
         // by BaseKmpWorker to populate TelemetryHook events and ExecutionRecord. Namespaced
-        // (kmp_ prefix) rather than a bare name like "chainId" because WorkContinuation.then()
-        // merges a prerequisite step's outputData into the next step's inputData via the default
+        // (kmp_ prefix) rather than a bare key because WorkContinuation.then() merges a
+        // prerequisite step's outputData into the next step's inputData via the default
         // OverwritingInputMerger — a user worker whose own outputData happened to use a bare key
         // would silently clobber this stamp for step 2+.
         const val KEY_CHAIN_ID = "kmp_chain_id"
         const val KEY_STEP_INDEX = "kmp_step_index"
         const val KEY_TOTAL_STEPS = "kmp_total_steps"
+        // Per-task deadline: Unix epoch ms. BaseKmpWorker checks this before calling doWork().
+        const val KEY_DEADLINE_MS = "kmp_deadline_ms"
+        // InputMerger: flag indicating the previous step's output should be merged into inputJson.
+        const val KEY_MERGE_PREVIOUS_OUTPUT = "kmp_merge_previous_output"
+        /**
+         * InputMerger transport key. [BaseKmpWorker] writes the worker's
+         * `WorkerResult.Success.data` here as a JSON string on success; WorkManager's default
+         * `OverwritingInputMerger` then copies it into the next chain step's `inputData`,
+         * where [BaseKmpWorker] reads it back if that step set [KEY_MERGE_PREVIOUS_OUTPUT].
+         *
+         * Namespaced for the same reason as [KEY_CHAIN_ID]: everything a prerequisite emits
+         * lands in the successor's input, so a bare key could be clobbered by a user worker.
+         */
+        const val KEY_STEP_OUTPUT = "kmp_step_output"
         internal const val OVERFLOW_THRESHOLD_BYTES = 8192 // 8 KB
         private const val ZOMBIE_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000L // 24 hours
         private val cleanupStarted = java.util.concurrent.atomic.AtomicBoolean(false)
@@ -106,12 +120,37 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String>,
+        deadlineMs: Long?
     ): ScheduleResult {
+        // Carries the standalone task's tags/deadline down the same path chain steps use,
+        // so `enqueue(tags = ...)` and `TaskRequest(tags = ...)` are stamped identically.
+        val taskMeta = TaskRequest(
+            workerClassName = workerClassName,
+            inputJson = inputJson,
+            constraints = constraints,
+            tags = tags,
+            deadlineMs = deadlineMs
+        )
+
+        // Exact alarms bypass WorkManager entirely (AlarmManager + AlarmReceiver), so the
+        // tag index and the inputData deadline stamp are both unavailable on that path.
+        // Warn instead of silently dropping — a caller who tagged a task expects
+        // cancelByTag() to reach it.
+        if (trigger is TaskTrigger.Exact && (tags.isNotEmpty() || deadlineMs != null)) {
+            Logger.w(
+                LogTags.SCHEDULER,
+                "Task '$id' uses TaskTrigger.Exact: tags and deadlineMs are NOT supported on the " +
+                    "exact-alarm path (it uses AlarmManager, not WorkManager). cancelByTag() will not " +
+                    "match this task — cancel it by id instead."
+            )
+        }
+
         val result = when (trigger) {
             is TaskTrigger.Exact -> scheduleExactAlarm(id, trigger, workerClassName, constraints, inputJson, policy)
-            is TaskTrigger.Periodic -> schedulePeriodicWork(id, trigger, workerClassName, constraints, inputJson, policy)
-            is TaskTrigger.ContentUri -> scheduleContentUriWork(id, trigger, workerClassName, constraints, inputJson, policy)
+            is TaskTrigger.Periodic -> schedulePeriodicWork(id, trigger, workerClassName, constraints, inputJson, policy, taskMeta)
+            is TaskTrigger.ContentUri -> scheduleContentUriWork(id, trigger, workerClassName, constraints, inputJson, policy, taskMeta)
             is TaskTrigger.Windowed -> {
                 val now = System.currentTimeMillis()
                 if (trigger.latest < now) {
@@ -120,13 +159,18 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
                 } else {
                     val delayMs = (trigger.earliest - now).coerceAtLeast(0L)
                     val updatedConstraints = constraints.copy()
+                    // A Windowed trigger's `latest` IS a deadline, so honour it as one even when
+                    // the caller passed no explicit deadlineMs. WorkManager cannot enforce
+                    // `latest` itself; stamping it here lets BaseKmpWorker skip a run the OS
+                    // delayed past the window (iOS ChainExecutor already does this for chains).
                     scheduleOneTimeWork(
                         id, TaskTrigger.OneTime(initialDelayMs = delayMs),
-                        workerClassName, updatedConstraints, inputJson, policy
+                        workerClassName, updatedConstraints, inputJson, policy,
+                        taskMeta.copy(deadlineMs = deadlineMs ?: trigger.latest)
                     )
                 }
             }
-            is TaskTrigger.OneTime -> scheduleOneTimeWork(id, trigger, workerClassName, constraints, inputJson, policy)
+            is TaskTrigger.OneTime -> scheduleOneTimeWork(id, trigger, workerClassName, constraints, inputJson, policy, taskMeta)
         }
 
         if (result == ScheduleResult.ACCEPTED) {
@@ -157,13 +201,15 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        taskMeta: TaskRequest? = null
     ): ScheduleResult {
         Logger.i(LogTags.SCHEDULER, "Scheduling one-time task - ID: '$id', Delay: ${trigger.initialDelayMs}ms")
 
         val workManagerPolicy = when (policy) {
             ExistingPolicy.KEEP -> ExistingWorkPolicy.KEEP
-            ExistingPolicy.REPLACE -> ExistingWorkPolicy.REPLACE
+            ExistingPolicy.REPLACE,
+            ExistingPolicy.UPDATE -> ExistingWorkPolicy.REPLACE  // UPDATE has no meaning for one-time tasks
         }
 
         val wmConstraints = buildWorkManagerConstraints(constraints)
@@ -171,7 +217,8 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
             Logger.d(LogTags.SCHEDULER, "Building request for $workerClassName")
             buildOneTimeWorkRequest(
                 id, workerClassName, constraints, inputJson,
-                "one-time", trigger.initialDelayMs, wmConstraints
+                "one-time", trigger.initialDelayMs, wmConstraints,
+                task = taskMeta
             )
         } catch (e: IllegalArgumentException) {
             Logger.e(LogTags.SCHEDULER, "Rejecting one-time task '$id': ${e.message}", e)
@@ -191,7 +238,8 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        taskMeta: TaskRequest? = null
     ): ScheduleResult {
         val intervalMs = trigger.intervalMs
         // WorkManager requires flexMs >= 5 min. Default to half the interval when not specified.
@@ -215,6 +263,10 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         val workManagerPolicy = when (policy) {
             ExistingPolicy.KEEP -> androidx.work.ExistingPeriodicWorkPolicy.KEEP
             ExistingPolicy.REPLACE -> androidx.work.ExistingPeriodicWorkPolicy.REPLACE
+            // UPDATE: preserve the existing schedule interval — only constraints/input change.
+            // Requires WorkManager 2.8+. Safe to use: minSdk for this lib is API 26 (WM 2.7 era)
+            // but WM 2.8 is pulled transitively via androidx.work:work-runtime:2.8+.
+            ExistingPolicy.UPDATE -> androidx.work.ExistingPeriodicWorkPolicy.UPDATE
         }
 
         val wmConstraints = buildWorkManagerConstraints(constraints)
@@ -243,6 +295,21 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
             .addTag("id-$id")
             .addTag("worker-$workerClassName")
 
+        // Same "user-" namespacing as one-time work so cancelByTag() resolves periodic tasks too.
+        taskMeta?.tags?.forEach { builder.addTag("user-$it") }
+
+        // NOTE: deadlineMs is deliberately NOT stamped for periodic work. A deadline is a
+        // one-shot concept ("skip if it hasn't started by T"); applied to a recurring task it
+        // would permanently disable every future run once T passes, which is a cancel, not a
+        // deadline. Callers wanting that should cancel the task instead.
+        if (taskMeta?.deadlineMs != null) {
+            Logger.w(
+                LogTags.SCHEDULER,
+                "Periodic task '$id' declared deadlineMs — ignored. A deadline would silently kill " +
+                    "every run after it elapses; cancel the task instead."
+            )
+        }
+
         workManager.enqueueUniquePeriodicWork(id, workManagerPolicy, builder.build())
         return ScheduleResult.ACCEPTED
     }
@@ -254,11 +321,13 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        taskMeta: TaskRequest? = null
     ): ScheduleResult {
         val workManagerPolicy = when (policy) {
             ExistingPolicy.KEEP -> ExistingWorkPolicy.KEEP
-            ExistingPolicy.REPLACE -> ExistingWorkPolicy.REPLACE
+            ExistingPolicy.REPLACE,
+            ExistingPolicy.UPDATE -> ExistingWorkPolicy.REPLACE
         }
 
         val wmConstraints = buildWorkManagerConstraints(constraints) { builder ->
@@ -271,7 +340,8 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         val workRequest = try {
             buildOneTimeWorkRequest(
                 id, workerClassName, constraints, inputJson,
-                "content-uri", 0L, wmConstraints
+                "content-uri", 0L, wmConstraints,
+                task = taskMeta
             )
         } catch (e: IllegalArgumentException) {
             return ScheduleResult.REJECTED_OS_POLICY
@@ -353,9 +423,15 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         wmConstraints: androidx.work.Constraints,
         chainId: String? = null,
         stepIndex: Int? = null,
-        totalSteps: Int? = null
+        totalSteps: Int? = null,
+        task: TaskRequest? = null
     ): OneTimeWorkRequest {
-        val workData = buildWorkData(id, workerClassName, inputJson, constraints.maxRetries, chainId, stepIndex, totalSteps)
+        val workData = buildWorkData(
+            id, workerClassName, inputJson, constraints.maxRetries,
+            chainId, stepIndex, totalSteps,
+            deadlineMs = task?.deadlineMs,
+            mergeOutputFromPreviousStep = task?.mergeOutputFromPreviousStep ?: false
+        )
         val builder = if (constraints.isHeavyTask) {
             OneTimeWorkRequestBuilder<KmpHeavyWorker>()
         } else {
@@ -375,6 +451,10 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
             .addTag("id-$id")
             .addTag("worker-$workerClassName")
 
+        // Stamp user-defined tags from TaskRequest so cancelByTag() can resolve them.
+        // Tag format: "user-<tag>" to avoid collisions with our internal "worker-", "id-", etc.
+        task?.tags?.forEach { builder.addTag("user-$it") }
+
         if (initialDelayMs == 0L && !constraints.isHeavyTask) {
             // Expedited work does not support some constraints like charging.
             // Safe to set only if it's a simple urgent task.
@@ -393,7 +473,9 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         maxRetries: Int,
         chainId: String? = null,
         stepIndex: Int? = null,
-        totalSteps: Int? = null
+        totalSteps: Int? = null,
+        deadlineMs: Long? = null,
+        mergeOutputFromPreviousStep: Boolean = false
     ): Data {
         val builder = Data.Builder().putString("workerClassName", workerClassName)
         // Stamp the retry ceiling before any early return so null-input tasks are capped too.
@@ -401,6 +483,10 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         if (chainId != null) builder.putString(KEY_CHAIN_ID, chainId)
         if (stepIndex != null) builder.putInt(KEY_STEP_INDEX, stepIndex)
         if (totalSteps != null) builder.putInt(KEY_TOTAL_STEPS, totalSteps)
+        // Stamp deadline so BaseKmpWorker can skip the task if it runs too late.
+        if (deadlineMs != null) builder.putLong(KEY_DEADLINE_MS, deadlineMs)
+        // Stamp InputMerger flag so BaseKmpWorker merges the previous step's output.
+        if (mergeOutputFromPreviousStep) builder.putBoolean(KEY_MERGE_PREVIOUS_OUTPUT, true)
         if (inputJson == null) return builder.build()
 
         val bytes = inputJson.encodeToByteArray()
@@ -485,6 +571,28 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
     }
 
     /**
+     * Cancels all pending or running tasks that carry the given user-defined tag.
+     *
+     * Tags are stamped as `"user-<tag>"` in WorkManager so they don't collide with
+     * the library's own internal tags (`"worker-*"`, `"id-*"`, `"type-*"`).
+     */
+    override fun cancelByTag(tag: String) {
+        Logger.i(LogTags.SCHEDULER, "Cancelling tasks by tag '$tag'")
+        workManager.cancelAllWorkByTag("user-$tag")
+    }
+
+    /**
+     * Cancels all pending or running tasks whose workerClassName matches [workerClassName].
+     *
+     * Uses the `"worker-<className>"` tag that is stamped on every WorkRequest by
+     * [buildOneTimeWorkRequest] and [schedulePeriodicWork].
+     */
+    override fun cancelByWorkerClass(workerClassName: String) {
+        Logger.i(LogTags.SCHEDULER, "Cancelling tasks by worker class '$workerClassName'")
+        workManager.cancelAllWorkByTag("worker-$workerClassName")
+    }
+
+    /**
      * Cancels the AlarmManager PendingIntent for the given task ID.
      * Uses FLAG_NO_CREATE to look up the existing PendingIntent without creating a new one.
      * Safe to call even if no alarm was ever scheduled for this ID.
@@ -526,7 +634,8 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
         val chainId = id ?: java.util.UUID.randomUUID().toString()
         val totalSteps = steps.size
         val wmPolicy = when (policy) {
-            ExistingPolicy.REPLACE -> ExistingWorkPolicy.REPLACE
+            ExistingPolicy.REPLACE,
+            ExistingPolicy.UPDATE -> ExistingWorkPolicy.REPLACE
             ExistingPolicy.KEEP -> ExistingWorkPolicy.KEEP
         }
 
@@ -561,7 +670,8 @@ open class NativeTaskScheduler(private val context: Context) : BackgroundTaskSch
             wmConstraints,
             chainId,
             stepIndex,
-            totalSteps
+            totalSteps,
+            task = task  // Pass full TaskRequest to stamp tags, deadlineMs, mergeOutputFromPreviousStep
         )
     }
 

--- a/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V350DeadlineAndInputMergerTest.kt
+++ b/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V350DeadlineAndInputMergerTest.kt
@@ -202,6 +202,24 @@ class V350DeadlineAndInputMergerTest {
     }
 
     @Test
+    fun workerWithNullData_doesNotRepublishThePreviousStepsOutput() {
+        // Guards a stale-data leak specific to how Android carries the payload.
+        // Step N's inputData physically CONTAINS step N-1's output (that is the transport).
+        // If a worker that produces nothing echoed its own input back out, step N+1 would be
+        // handed step N-1's output as though step N had produced it — a silent, very
+        // confusing data corruption in a pipeline. The output must reflect only this worker.
+        val outcome = runWorker(
+            result = WorkerResult.Success(data = null),
+            mergePreviousOutput = true,
+            previousStepOutput = """{"filePath":"/tmp/stale.zip"}"""
+        )
+        assertNull(
+            (outcome as Result.Success).outputData.getString(NativeTaskScheduler.KEY_STEP_OUTPUT),
+            "A worker returning no data must publish nothing — never re-emit the previous step's output."
+        )
+    }
+
+    @Test
     fun oversizedOutput_isDroppedRatherThanFailingTheStep() {
         // WorkManager rejects Data over its limit at build time. Forwarding must degrade to
         // "no data" instead of turning a worker that genuinely succeeded into a failure.

--- a/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V350DeadlineAndInputMergerTest.kt
+++ b/kmpworker/src/androidUnitTest/kotlin/dev/brewkits/kmpworkmanager/background/data/V350DeadlineAndInputMergerTest.kt
@@ -1,0 +1,276 @@
+package dev.brewkits.kmpworkmanager.background.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Data
+import androidx.work.ListenableWorker.Result
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import dev.brewkits.kmpworkmanager.KmpWorkManagerRuntime
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorker
+import dev.brewkits.kmpworkmanager.background.domain.AndroidWorkerFactory
+import dev.brewkits.kmpworkmanager.background.domain.ExecutionRecord
+import dev.brewkits.kmpworkmanager.background.domain.ExecutionStatus
+import dev.brewkits.kmpworkmanager.background.domain.WorkerEnvironment
+import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
+import dev.brewkits.kmpworkmanager.persistence.ExecutionHistoryStore
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Android-side coverage for two features that are easy to ship broken because they
+ * *look* wired up while doing nothing:
+ *
+ * 1. **`TaskRequest.deadlineMs`** — a stale task must be skipped, and skipped in a way that
+ *    does not make WorkManager retry it forever.
+ * 2. **`TaskRequest.mergeOutputFromPreviousStep`** — the InputMerger. Android cannot pass a
+ *    `JsonObject` between steps directly; it round-trips through WorkManager output `Data`
+ *    (`KEY_STEP_OUTPUT`) and back. The first implementation stamped the *flag* but never
+ *    emitted or read the *payload*, so the feature silently no-opped on Android while
+ *    working on iOS. These tests fail if that regresses.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class V350DeadlineAndInputMergerTest {
+
+    private lateinit var context: Context
+    private val savedRecords = mutableListOf<ExecutionRecord>()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        savedRecords.clear()
+        KmpWorkManagerRuntime.executionHistoryStore = object : ExecutionHistoryStore {
+            override suspend fun save(record: ExecutionRecord) { savedRecords += record }
+            override suspend fun getRecords(limit: Int): List<ExecutionRecord> = savedRecords.toList()
+            override suspend fun clear() { savedRecords.clear() }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        KmpWorkManagerRuntime.executionHistoryStore = null
+        InputCapturingWorker.lastInputJson = null
+    }
+
+    // ── Deadline ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun deadlineInThePast_skipsWorkerEntirely() {
+        val outcome = runWorker(
+            result = WorkerResult.Success(),
+            deadlineMs = System.currentTimeMillis() - 60_000
+        )
+        assertTrue(outcome is Result.Success, "A missed deadline must not surface as a failure. Got: $outcome")
+        assertNull(
+            InputCapturingWorker.lastInputJson,
+            "The worker body must never run once the deadline has passed — that is the whole point."
+        )
+    }
+
+    @Test
+    fun deadlineInThePast_returnsSuccessNotRetry_soWorkManagerStopsRescheduling() {
+        // Result.retry() here would be a slow-motion disaster: the task can never meet a
+        // deadline that is already gone, so it would retry until its backoff budget is spent.
+        val outcome = runWorker(
+            result = WorkerResult.Success(),
+            deadlineMs = System.currentTimeMillis() - 60_000
+        )
+        assertTrue(outcome !is Result.Retry, "A deadline miss must never schedule a retry. Got: $outcome")
+    }
+
+    @Test
+    fun deadlineInThePast_recordsSkippedStatusInHistory() {
+        runWorker(result = WorkerResult.Success(), deadlineMs = System.currentTimeMillis() - 60_000)
+        assertEquals(
+            ExecutionStatus.SKIPPED, savedRecords.single().status,
+            "History must distinguish 'skipped for staleness' from 'succeeded'."
+        )
+    }
+
+    @Test
+    fun deadlineInTheFuture_runsNormally() {
+        runWorker(result = WorkerResult.Success(), deadlineMs = System.currentTimeMillis() + 60_000)
+        assertNotNull(InputCapturingWorker.lastInputJson, "A future deadline must not block execution.")
+        assertEquals(ExecutionStatus.SUCCESS, savedRecords.single().status)
+    }
+
+    @Test
+    fun absentDeadline_runsNormally_backCompat() {
+        runWorker(result = WorkerResult.Success(), deadlineMs = null)
+        assertNotNull(InputCapturingWorker.lastInputJson)
+        assertEquals(ExecutionStatus.SUCCESS, savedRecords.single().status)
+    }
+
+    // ── InputMerger ───────────────────────────────────────────────────────────
+
+    @Test
+    fun successfulWorker_publishesOutputForTheNextStep() {
+        // This is the half that was missing: without an output Data payload,
+        // WorkManager's OverwritingInputMerger has nothing to hand the successor.
+        val outcome = runWorker(
+            result = WorkerResult.Success(data = buildJsonObject { put("filePath", "/tmp/x.zip") })
+        )
+        val output = (outcome as Result.Success).outputData
+        val raw = output.getString(NativeTaskScheduler.KEY_STEP_OUTPUT)
+        assertNotNull(raw, "A successful worker must publish its data under KEY_STEP_OUTPUT.")
+        assertEquals("/tmp/x.zip", (Json.parseToJsonElement(raw) as JsonObject)["filePath"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun workerWithNullData_publishesNoOutput() {
+        val outcome = runWorker(result = WorkerResult.Success(data = null))
+        assertNull(
+            (outcome as Result.Success).outputData.getString(NativeTaskScheduler.KEY_STEP_OUTPUT),
+            "Nothing to forward means no key at all, not an empty string."
+        )
+    }
+
+    @Test
+    fun mergeFlagSet_previousOutputReachesTheWorkerInput() {
+        val outcome = runWorker(
+            result = WorkerResult.Success(),
+            inputJson = """{"url":"https://host"}""",
+            mergePreviousOutput = true,
+            previousStepOutput = """{"filePath":"/tmp/x.zip"}"""
+        )
+        assertTrue(outcome is Result.Success)
+
+        val received = Json.parseToJsonElement(assertNotNull(InputCapturingWorker.lastInputJson)) as JsonObject
+        assertEquals("https://host", received["url"]?.jsonPrimitive?.content, "Own input must survive the merge.")
+        assertEquals("/tmp/x.zip", received["filePath"]?.jsonPrimitive?.content, "Previous step's output must arrive.")
+    }
+
+    @Test
+    fun mergeFlagSet_previousOutputWinsOnKeyCollision() {
+        runWorker(
+            result = WorkerResult.Success(),
+            inputJson = """{"retries":3}""",
+            mergePreviousOutput = true,
+            previousStepOutput = """{"retries":1}"""
+        )
+        val received = Json.parseToJsonElement(assertNotNull(InputCapturingWorker.lastInputJson)) as JsonObject
+        assertEquals(
+            "1", received["retries"]?.jsonPrimitive?.content,
+            "Android must match iOS and WorkManager's OverwritingInputMerger: previous step wins."
+        )
+    }
+
+    @Test
+    fun mergeFlagNotSet_previousOutputIsIgnored() {
+        // Opt-in only. A step that did not ask for merging must see exactly its own input,
+        // even though the payload is physically present in its inputData.
+        runWorker(
+            result = WorkerResult.Success(),
+            inputJson = """{"url":"https://host"}""",
+            mergePreviousOutput = false,
+            previousStepOutput = """{"filePath":"/tmp/x.zip"}"""
+        )
+        val received = Json.parseToJsonElement(assertNotNull(InputCapturingWorker.lastInputJson)) as JsonObject
+        assertNull(received["filePath"], "Without the opt-in flag the previous output must not leak in.")
+        assertEquals("https://host", received["url"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun mergeFlagSet_butNoPreviousOutput_leavesOwnInputIntact() {
+        // First step of a chain, or a predecessor that returned no data.
+        runWorker(
+            result = WorkerResult.Success(),
+            inputJson = """{"url":"https://host"}""",
+            mergePreviousOutput = true,
+            previousStepOutput = null
+        )
+        val received = Json.parseToJsonElement(assertNotNull(InputCapturingWorker.lastInputJson)) as JsonObject
+        assertEquals(
+            "https://host", received["url"]?.jsonPrimitive?.content,
+            "A missing previous output must not blank out the task's own input."
+        )
+    }
+
+    @Test
+    fun oversizedOutput_isDroppedRatherThanFailingTheStep() {
+        // WorkManager rejects Data over its limit at build time. Forwarding must degrade to
+        // "no data" instead of turning a worker that genuinely succeeded into a failure.
+        val huge = buildJsonObject { put("blob", "x".repeat(NativeTaskScheduler.OVERFLOW_THRESHOLD_BYTES + 1024)) }
+        val outcome = runWorker(result = WorkerResult.Success(data = huge))
+        assertTrue(outcome is Result.Success, "An oversized output must not fail the step. Got: $outcome")
+        assertNull(
+            (outcome as Result.Success).outputData.getString(NativeTaskScheduler.KEY_STEP_OUTPUT),
+            "Oversized payloads are dropped, not truncated or spilled."
+        )
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────────
+
+    private fun runWorker(
+        result: WorkerResult,
+        inputJson: String? = """{"seed":true}""",
+        deadlineMs: Long? = null,
+        mergePreviousOutput: Boolean = false,
+        previousStepOutput: String? = null
+    ): Result {
+        InputCapturingWorker.factoryHolder = AndroidWorkerFactory_Capturing(result)
+        InputCapturingWorker.lastInputJson = null
+
+        val builder = Data.Builder().putString("workerClassName", "CapturingWorker")
+        if (inputJson != null) builder.putString("inputJson", inputJson)
+        if (deadlineMs != null) builder.putLong(NativeTaskScheduler.KEY_DEADLINE_MS, deadlineMs)
+        if (mergePreviousOutput) builder.putBoolean(NativeTaskScheduler.KEY_MERGE_PREVIOUS_OUTPUT, true)
+        // Simulates what WorkManager's OverwritingInputMerger does for a chained step:
+        // the prerequisite's output Data is present in this step's inputData.
+        if (previousStepOutput != null) builder.putString(NativeTaskScheduler.KEY_STEP_OUTPUT, previousStepOutput)
+
+        val worker = TestListenableWorkerBuilder<InputCapturingWorker>(context)
+            .setInputData(builder.build())
+            .build()
+        return runBlocking { worker.doWork() }
+    }
+}
+
+private class AndroidWorkerFactory_Capturing(private val result: WorkerResult) : AndroidWorkerFactory {
+    override fun createWorker(workerClassName: String): AndroidWorker = object : AndroidWorker {
+        override suspend fun doWork(input: String?, env: WorkerEnvironment): WorkerResult {
+            InputCapturingWorker.lastInputJson = input
+            return result
+        }
+    }
+}
+
+class InputCapturingWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : BaseKmpWorker(appContext, workerParams, factoryHolder!!) {
+
+    override val workerLogTag: String get() = "InputCapturingWorker"
+    override suspend fun doWork(): Result = doWorkInternal()
+    override suspend fun performWork(workerClassName: String, inputJson: String?): WorkerResult {
+        val worker = workerFactory.createWorker(workerClassName)
+            ?: return WorkerResult.Failure("not found")
+        return worker.doWork(inputJson, WorkerEnvironment(
+            progressListener = object : dev.brewkits.kmpworkmanager.background.domain.ProgressListener {
+                override fun onProgressUpdate(progress: dev.brewkits.kmpworkmanager.background.domain.WorkerProgress) {}
+            },
+            isCancelled = { false }
+        ))
+    }
+
+    companion object {
+        @Volatile var factoryHolder: AndroidWorkerFactory? = null
+        /** Input the user worker actually received — the assertion target for InputMerger. */
+        @Volatile var lastInputJson: String? = null
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/BackgroundTaskScheduler.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/BackgroundTaskScheduler.kt
@@ -17,6 +17,12 @@ interface BackgroundTaskScheduler {
      * @param constraints Optional conditions like network or charging requirements.
      * @param inputJson Optional data to pass to the worker.
      * @param policy Determines what happens if a task with the same ID is already pending.
+     * @param tags User-defined labels for group cancellation via [cancelByTag]. Independent of
+     * [workerClassName] — tasks of different worker types can share a business-context tag.
+     * See [TaskRequest.tags] for the chain-step equivalent.
+     * @param deadlineMs Optional Unix epoch millisecond deadline. If the task has not started
+     * by this time it is skipped instead of executed, so a delayed run cannot produce stale
+     * data. See [TaskRequest.deadlineMs] for the chain-step equivalent.
      * @return [ScheduleResult] indicating if the OS accepted the request.
      */
     suspend fun enqueue(
@@ -25,7 +31,9 @@ interface BackgroundTaskScheduler {
         workerClassName: String,
         constraints: Constraints = Constraints(),
         inputJson: String? = null,
-        policy: ExistingPolicy = ExistingPolicy.REPLACE
+        policy: ExistingPolicy = ExistingPolicy.REPLACE,
+        tags: Set<String> = emptySet(),
+        deadlineMs: Long? = null
     ): ScheduleResult
 
     /** Cancels a pending or running task by its unique ID. */
@@ -33,6 +41,47 @@ interface BackgroundTaskScheduler {
 
     /** Cancels all background tasks managed by this scheduler. */
     fun cancelAll()
+
+    /**
+     * Cancels all pending or running tasks that carry the given user-defined tag.
+     *
+     * Matches both standalone tasks (see the `tags` parameter of [enqueue]) and chain steps
+     * (see [TaskRequest.tags]); a caller thinks in terms of "cancel my work", not in terms
+     * of which API scheduled it.
+     *
+     * ```kotlin
+     * // Cancel every task related to a user session, whatever worker it uses:
+     * scheduler.cancelByTag("user-123")
+     * ```
+     *
+     * **Not supported for [TaskTrigger.Exact]** on Android: exact alarms run through
+     * `AlarmManager` rather than WorkManager and are not tag-indexed. Cancel those by id.
+     *
+     * Has a no-op default so that adding this method does not break existing third-party
+     * implementations of this interface (test doubles in particular). Real schedulers
+     * override it; the default logs nothing and cancels nothing.
+     */
+    fun cancelByTag(tag: String) {
+        // Intentionally empty: see KDoc. A custom scheduler that never implemented tagging
+        // has nothing to cancel, and throwing here would break callers of a working app.
+    }
+
+    /**
+     * Cancels all pending or running tasks whose worker class name matches
+     * [workerClassName] — standalone tasks and chain steps alike.
+     *
+     * Grouping is by worker *type* rather than by business context; use [cancelByTag] when
+     * you need to cancel a set of differently-typed workers that belong to one operation.
+     *
+     * ```kotlin
+     * scheduler.cancelByWorkerClass("SyncWorker")
+     * ```
+     *
+     * Has a no-op default for the same source-compatibility reason as [cancelByTag].
+     */
+    fun cancelByWorkerClass(workerClassName: String) {
+        // Intentionally empty: see cancelByTag.
+    }
 
     /**
      * Starts building a sequential or parallel task chain.

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/ChainInputMerger.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/ChainInputMerger.kt
@@ -1,0 +1,62 @@
+package dev.brewkits.kmpworkmanager.background.domain
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Shared implementation of the chain InputMerger used by [TaskRequest.mergeOutputFromPreviousStep].
+ *
+ * Lives in `commonMain` deliberately: Android and iOS execute chains through completely
+ * different engines (WorkManager's `WorkContinuation` vs. `ChainExecutor`), but the *merge
+ * semantics* a user observes must be identical on both. Keeping one implementation here is
+ * what makes that guarantee testable in `commonTest` rather than asserted twice.
+ */
+internal object ChainInputMerger {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Merges [previousOutput] into [baseInputJson].
+     *
+     * Semantics: **overwriting merge** — fields from [previousOutput] win over same-key
+     * fields in [baseInputJson]. This mirrors `OverwritingInputMerger`, WorkManager's
+     * default merger for chained work, so Android's native behaviour and iOS's emulated
+     * behaviour agree.
+     *
+     * ```
+     * base:     { "url": "https://host", "retries": 3 }
+     * previous: { "filePath": "/tmp/x.zip", "retries": 1 }
+     * result:   { "url": "https://host", "retries": 1, "filePath": "/tmp/x.zip" }
+     * ```
+     *
+     * A malformed or non-object [baseInputJson] is treated as empty rather than throwing:
+     * a chain must not die because an upstream worker wrote a bad input string. The
+     * previous step's output is still delivered, which is the more useful failure mode.
+     *
+     * @param baseInputJson The task's own `inputJson` (may be null, blank, or malformed).
+     * @param previousOutput The preceding step's `WorkerResult.Success.data`.
+     * @return A JSON object string safe to pass as the task's `inputJson`.
+     */
+    fun merge(baseInputJson: String?, previousOutput: JsonObject): String {
+        val baseElements: Map<String, JsonElement> = parseObjectOrEmpty(baseInputJson)
+        val merged = buildMap<String, JsonElement> {
+            putAll(baseElements)
+            putAll(previousOutput) // previous-step keys win on collision
+        }
+        return json.encodeToString(JsonObject.serializer(), JsonObject(merged))
+    }
+
+    /**
+     * Parses [raw] into a [JsonObject]'s entries, or returns an empty map when [raw] is
+     * null/blank, not valid JSON, or valid JSON that is not an object (e.g. `[1,2]`, `"x"`).
+     */
+    fun parseObjectOrEmpty(raw: String?): Map<String, JsonElement> {
+        if (raw.isNullOrBlank()) return emptyMap()
+        return try {
+            (json.parseToJsonElement(raw) as? JsonObject)?.toMap() ?: emptyMap()
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+}

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/Contracts.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/Contracts.kt
@@ -156,10 +156,22 @@ enum class ExactAlarmIOSBehavior {
 
 /**
  * Policy for handling a new task when one with the same ID already exists.
+ *
+ * - [KEEP]: The new request is silently discarded. The existing task runs unchanged.
+ * - [REPLACE]: The existing task is cancelled and replaced with the new request.
+ *   For periodic tasks, this **resets the interval timer** (the next run is scheduled
+ *   from `now + initialDelay`, not from the original anchor time).
+ * - [UPDATE]: The existing periodic task's constraints and input are updated **without**
+ *   resetting the interval timer. The next execution time is preserved. Ignored for
+ *   one-time tasks (treated as [REPLACE]).
+ *   - Android: maps to `ExistingPeriodicWorkPolicy.UPDATE` (WorkManager 2.8+).
+ *   - iOS: preserves `anchoredStartMs` from the existing metadata and resubmits the
+ *     BGTask request with the same drift-corrected `earliestBeginDate`.
  */
 enum class ExistingPolicy {
     KEEP,
-    REPLACE
+    REPLACE,
+    UPDATE
 }
 
 /**

--- a/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskChain.kt
+++ b/kmpworker/src/commonMain/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskChain.kt
@@ -4,6 +4,48 @@ import kotlinx.serialization.Serializable
 
 /**
  * A TaskRequest represents a single unit of work to be scheduled.
+ *
+ * @property workerClassName The class name of the worker to execute.
+ * @property inputJson Optional JSON string passed to the worker's `doWork()` call.
+ * @property constraints Optional per-step constraints. If null, the chain-level constraints apply.
+ * @property priority Execution priority relative to other tasks in the queue.
+ * @property isIdempotent Whether this task can be safely retried from the beginning after a crash.
+ *   Set to `false` for tasks with irreversible side-effects (e.g. payment, email send).
+ *   A chain with non-idempotent tasks is **quarantined** rather than restarted after a corrupt-progress
+ *   self-heal, preventing accidental double-execution.
+ * @property tags A set of user-defined labels for group cancellation.
+ *   Use `scheduler.cancelByTag("user-123")` to cancel all tasks carrying a given tag
+ *   regardless of worker class. Tags are independent of `workerClassName` — you can mix
+ *   workers of different types under the same business-context tag.
+ *   ```kotlin
+ *   // Enqueue tasks tagged with a user session
+ *   TaskRequest("SyncWorker", tags = setOf("user-123", "background-sync"))
+ *   TaskRequest("UploadWorker", tags = setOf("user-123"))
+ *
+ *   // Cancel everything for that user in one call:
+ *   scheduler.cancelByTag("user-123")
+ *   ```
+ * @property deadlineMs Optional Unix epoch millisecond deadline. If the task has not started
+ *   by this time, it is silently skipped with status `SKIPPED` instead of executing.
+ *   Useful for time-sensitive operations (push notification sync, pre-flight checks) that
+ *   produce stale data if they run too late.
+ *   - `null` (default) — no deadline, task always executes when scheduled.
+ *   - Affects both standalone tasks and chain steps.
+ * @property mergeOutputFromPreviousStep When `true`, the `JsonObject` output from the
+ *   immediately preceding step's `WorkerResult.Success.data` is merged into this task's
+ *   `inputJson` before `doWork()` is called. Merged fields from the previous step
+ *   **overwrite** same-key fields in the original `inputJson`.
+ *   Use this to build data-pipeline chains without an external store:
+ *   ```kotlin
+ *   scheduler
+ *       .beginWith(TaskRequest("DownloadWorker"))         // produces: {"filePath": "/tmp/x.zip"}
+ *       .then(TaskRequest("ValidateWorker",
+ *           mergeOutputFromPreviousStep = true))           // receives: {"filePath": "/tmp/x.zip"}
+ *       .then(TaskRequest("UploadWorker",
+ *           mergeOutputFromPreviousStep = true))           // receives: {"filePath": "/tmp/x.zip"}
+ *       .enqueue()
+ *   ```
+ *   Default: `false` — opt-in to preserve backward compatibility.
  */
 @Serializable
 data class TaskRequest(
@@ -11,8 +53,47 @@ data class TaskRequest(
     val inputJson: String? = null,
     val constraints: Constraints? = null,
     val priority: TaskPriority = TaskPriority.NORMAL,
-    val isIdempotent: Boolean = true
-)
+    val isIdempotent: Boolean = true,
+    val tags: Set<String> = emptySet(),
+    val deadlineMs: Long? = null,
+    val mergeOutputFromPreviousStep: Boolean = false
+) {
+    init {
+        tags.forEach { validateTaskTag(it) }
+    }
+}
+
+/**
+ * Rejects tags that cannot round-trip through both platforms' tag storage.
+ *
+ * Validation lives at the API boundary on purpose: a tag that survives scheduling but
+ * cannot be matched later would make [BackgroundTaskScheduler.cancelByTag] silently
+ * fail to cancel — the worst possible failure mode for a cancellation API. Failing at
+ * enqueue time turns that into an immediate, obvious programming error.
+ *
+ * Rules, and why each exists:
+ * - **Non-blank** — a blank tag matches nothing and is always a bug.
+ * - **No commas** — iOS persists a standalone task's tags as one comma-separated
+ *   metadata string ([DynamicTaskDispatcher.META_TAGS]); an embedded comma would split
+ *   one tag into two.
+ * - **Max 100 chars** — Android stores tags in WorkManager's SQLite tag table; this keeps
+ *   a runaway tag from bloating every row.
+ *
+ * @throws IllegalArgumentException if [tag] violates any rule.
+ */
+internal fun validateTaskTag(tag: String) {
+    require(tag.isNotBlank()) { "Task tag must not be blank." }
+    require(',' !in tag) {
+        "Task tag must not contain a comma (got: '$tag'). Commas are the separator used to " +
+            "persist tags in iOS task metadata, so an embedded comma would split the tag."
+    }
+    require(tag.length <= MAX_TASK_TAG_LENGTH) {
+        "Task tag must be at most $MAX_TASK_TAG_LENGTH characters (got ${tag.length}: '${tag.take(30)}…')."
+    }
+}
+
+/** Maximum length of a single task tag. See [validateTaskTag]. */
+internal const val MAX_TASK_TAG_LENGTH = 100
 
 /**
  * TaskChain builder for sequential and parallel task execution.

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/EdgeCasesTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/EdgeCasesTest.kt
@@ -234,11 +234,15 @@ class EdgeCasesTest {
             workerClassName: String,
             constraints: Constraints,
             inputJson: String?,
-            policy: ExistingPolicy
+            policy: ExistingPolicy,
+            tags: Set<String>,
+            deadlineMs: Long?
         ): ScheduleResult = ScheduleResult.ACCEPTED
 
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
 
         override fun beginWith(task: TaskRequest): TaskChain {
             return TaskChain(this, listOf(task))

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/TaskChainTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/TaskChainTest.kt
@@ -72,11 +72,15 @@ class TaskChainTest {
             workerClassName: String,
             constraints: Constraints,
             inputJson: String?,
-            policy: ExistingPolicy
+            policy: ExistingPolicy,
+            tags: Set<String>,
+            deadlineMs: Long?
         ): ScheduleResult = ScheduleResult.ACCEPTED
 
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
 
         override fun beginWith(task: TaskRequest): TaskChain {
             return TaskChain(this, listOf(task))

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/V233BugFixesTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/V233BugFixesTest.kt
@@ -277,11 +277,15 @@ class V233BugFixesTest {
             workerClassName: String,
             constraints: Constraints,
             inputJson: String?,
-            policy: ExistingPolicy
+            policy: ExistingPolicy,
+            tags: Set<String>,
+            deadlineMs: Long?
         ): ScheduleResult = ScheduleResult.ACCEPTED
 
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
 
         override fun beginWith(task: TaskRequest) = TaskChain(this, listOf(task))
         override fun beginWith(tasks: List<TaskRequest>) = TaskChain(this, tasks)

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/ChainInputMergerTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/ChainInputMergerTest.kt
@@ -1,0 +1,124 @@
+package dev.brewkits.kmpworkmanager.background.domain
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Contract tests for [ChainInputMerger] — the shared engine behind
+ * [TaskRequest.mergeOutputFromPreviousStep].
+ *
+ * These live in `commonTest` on purpose. The merge runs inside two completely different
+ * chain engines (Android's `BaseKmpWorker` reading WorkManager `Data`, iOS's `ChainExecutor`
+ * passing a `JsonObject` in memory), so the only way "both platforms merge identically"
+ * stays true is if both call one implementation that is pinned here.
+ */
+class ChainInputMergerTest {
+
+    private fun parse(raw: String): JsonObject =
+        Json.parseToJsonElement(raw) as JsonObject
+
+    @Test
+    fun previousOutputWins_onKeyCollision() {
+        val base = """{"url":"https://host","retries":3}"""
+        val previous = buildJsonObject {
+            put("filePath", "/tmp/x.zip")
+            put("retries", 1)
+        }
+
+        val merged = parse(ChainInputMerger.merge(base, previous))
+
+        assertEquals("https://host", merged["url"]?.jsonPrimitive?.content, "Untouched base keys must survive.")
+        assertEquals("/tmp/x.zip", merged["filePath"]?.jsonPrimitive?.content, "New keys from the previous step must appear.")
+        assertEquals(
+            "1", merged["retries"]?.jsonPrimitive?.content,
+            "On collision the PREVIOUS step's value must win — this is the documented " +
+                "OverwritingInputMerger semantic that Android relies on natively."
+        )
+    }
+
+    @Test
+    fun nullBaseInput_yieldsPreviousOutputAlone() {
+        val previous = buildJsonObject { put("token", "abc") }
+        val merged = parse(ChainInputMerger.merge(null, previous))
+        assertEquals(1, merged.size)
+        assertEquals("abc", merged["token"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun blankBaseInput_yieldsPreviousOutputAlone() {
+        val previous = buildJsonObject { put("token", "abc") }
+        assertEquals(
+            parse(ChainInputMerger.merge(null, previous)),
+            parse(ChainInputMerger.merge("   ", previous)),
+            "A blank input string must behave exactly like a null one."
+        )
+    }
+
+    @Test
+    fun malformedBaseInput_doesNotThrow_andStillDeliversPreviousOutput() {
+        // A worker that wrote a bad input string must not be able to kill the chain:
+        // losing the malformed input is recoverable, losing the step is not.
+        val previous = buildJsonObject { put("token", "abc") }
+        val merged = parse(ChainInputMerger.merge("{not valid json", previous))
+        assertEquals("abc", merged["token"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun nonObjectBaseInput_isTreatedAsEmpty() {
+        // Valid JSON, but not an object — there is nothing to merge INTO.
+        val previous = buildJsonObject { put("k", "v") }
+        for (raw in listOf("[1,2,3]", "\"a string\"", "42", "true", "null")) {
+            val merged = parse(ChainInputMerger.merge(raw, previous))
+            assertEquals(1, merged.size, "Base '$raw' should contribute no keys.")
+            assertEquals("v", merged["k"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun emptyPreviousOutput_preservesBaseInputExactly() {
+        val base = """{"url":"https://host","retries":3}"""
+        val merged = parse(ChainInputMerger.merge(base, JsonObject(emptyMap())))
+        assertEquals(parse(base), merged, "An empty previous output must not disturb the base input.")
+    }
+
+    @Test
+    fun nestedObjectsAreReplacedWholesale_notDeepMerged() {
+        // Documents the deliberate choice: this is a shallow merge, matching
+        // OverwritingInputMerger. A deep merge would silently blend two workers'
+        // nested structures in ways neither author intended.
+        val base = """{"config":{"a":1,"b":2}}"""
+        val previous = buildJsonObject {
+            put("config", buildJsonObject { put("a", 99) })
+        }
+        val merged = parse(ChainInputMerger.merge(base, previous))
+        val config = merged["config"] as JsonObject
+        assertEquals(1, config.size, "Nested object must be replaced, not deep-merged.")
+        assertEquals("99", config["a"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun mergedResultIsValidJsonObject_reParsable() {
+        // The result is fed straight back in as a task's inputJson, so it must round-trip.
+        val merged = ChainInputMerger.merge("""{"a":1}""", buildJsonObject { put("b", "x") })
+        val reparsed = parse(merged)
+        assertEquals(2, reparsed.size)
+        assertTrue(reparsed["a"]?.jsonPrimitive is JsonPrimitive)
+    }
+
+    @Test
+    fun parseObjectOrEmpty_handlesEveryDegenerateInput() {
+        assertEquals(emptyMap(), ChainInputMerger.parseObjectOrEmpty(null))
+        assertEquals(emptyMap(), ChainInputMerger.parseObjectOrEmpty(""))
+        assertEquals(emptyMap(), ChainInputMerger.parseObjectOrEmpty("   "))
+        assertEquals(emptyMap(), ChainInputMerger.parseObjectOrEmpty("{broken"))
+        assertEquals(emptyMap(), ChainInputMerger.parseObjectOrEmpty("[1,2]"))
+        assertEquals(1, ChainInputMerger.parseObjectOrEmpty("""{"a":1}""").size)
+    }
+}

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/DomainExtTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/DomainExtTest.kt
@@ -17,7 +17,9 @@ class DomainExtTest {
             workerClassName: String,
             constraints: Constraints,
             inputJson: String?,
-            policy: ExistingPolicy
+            policy: ExistingPolicy,
+            tags: Set<String>,
+            deadlineMs: Long?
         ): ScheduleResult {
             lastId = id
             lastPolicy = policy
@@ -28,6 +30,8 @@ class DomainExtTest {
 
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = TaskChain(this, listOf(task))
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = TaskChain(this, tasks)
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {}

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskChainLogicTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskChainLogicTest.kt
@@ -8,9 +8,11 @@ class TaskChainLogicTest {
     private class SimpleMockScheduler : BackgroundTaskScheduler {
         val enqueuedChains = mutableListOf<Pair<TaskChain, String?>>()
         
-        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy) = ScheduleResult.ACCEPTED
+        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy, tags: Set<String>, deadlineMs: Long?) = ScheduleResult.ACCEPTED
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = TaskChain(this, listOf(task))
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = TaskChain(this, tasks)
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskTagValidationTest.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/background/domain/TaskTagValidationTest.kt
@@ -1,0 +1,87 @@
+package dev.brewkits.kmpworkmanager.background.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Guards the tag contract behind [BackgroundTaskScheduler.cancelByTag].
+ *
+ * The stakes are specific: iOS persists a standalone task's tags as one comma-separated
+ * metadata string, so a tag containing a comma would be split in two on the way back out
+ * and `cancelByTag` would quietly fail to match it. A cancellation API that silently fails
+ * to cancel is worse than one that refuses the input, so [TaskRequest] rejects such tags at
+ * construction — these tests pin that.
+ */
+class TaskTagValidationTest {
+
+    @Test
+    fun validTags_areAccepted() {
+        val task = TaskRequest(
+            workerClassName = "SyncWorker",
+            tags = setOf("user-123", "background_sync", "com.example.scope", "tag with spaces", "标签")
+        )
+        assertEquals(5, task.tags.size)
+    }
+
+    @Test
+    fun emptyTagSet_isAccepted() {
+        assertTrue(TaskRequest(workerClassName = "SyncWorker").tags.isEmpty())
+    }
+
+    @Test
+    fun commaInTag_isRejected() {
+        // The critical case: comma is iOS's separator in META_TAGS.
+        val e = assertFailsWith<IllegalArgumentException> {
+            TaskRequest(workerClassName = "SyncWorker", tags = setOf("user,123"))
+        }
+        assertTrue(
+            e.message!!.contains("comma"),
+            "The failure must name the real reason so a caller can fix it. Got: ${e.message}"
+        )
+    }
+
+    @Test
+    fun blankTag_isRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            TaskRequest(workerClassName = "SyncWorker", tags = setOf(""))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            TaskRequest(workerClassName = "SyncWorker", tags = setOf("   "))
+        }
+    }
+
+    @Test
+    fun overlongTag_isRejected() {
+        val tooLong = "x".repeat(MAX_TASK_TAG_LENGTH + 1)
+        assertFailsWith<IllegalArgumentException> {
+            TaskRequest(workerClassName = "SyncWorker", tags = setOf(tooLong))
+        }
+    }
+
+    @Test
+    fun tagAtExactLengthLimit_isAccepted() {
+        // Boundary: the limit itself must be usable, not off-by-one rejected.
+        val exact = "x".repeat(MAX_TASK_TAG_LENGTH)
+        val task = TaskRequest(workerClassName = "SyncWorker", tags = setOf(exact))
+        assertEquals(exact, task.tags.single())
+    }
+
+    @Test
+    fun oneBadTagRejectsTheWholeRequest_notJustThatTag() {
+        // Partial acceptance would leave the caller believing all tags are cancellable.
+        assertFailsWith<IllegalArgumentException> {
+            TaskRequest(workerClassName = "SyncWorker", tags = setOf("good-tag", "bad,tag"))
+        }
+    }
+
+    @Test
+    fun copyWithBadTag_isAlsoRejected() {
+        // data class copy() re-runs init, so the guard cannot be bypassed by copying.
+        val ok = TaskRequest(workerClassName = "SyncWorker", tags = setOf("fine"))
+        assertFailsWith<IllegalArgumentException> {
+            ok.copy(tags = setOf("not,fine"))
+        }
+    }
+}

--- a/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/testing/FakeBackgroundTaskScheduler.kt
+++ b/kmpworker/src/commonTest/kotlin/dev/brewkits/kmpworkmanager/testing/FakeBackgroundTaskScheduler.kt
@@ -42,6 +42,12 @@ class FakeBackgroundTaskScheduler(
     /** IDs passed to [cancel]. */
     val cancelledIds: MutableList<String> = mutableListOf()
 
+    /** Tags passed to [cancelByTag], in call order. */
+    val cancelledTags: MutableList<String> = mutableListOf()
+
+    /** Worker class names passed to [cancelByWorkerClass], in call order. */
+    val cancelledWorkerClasses: MutableList<String> = mutableListOf()
+
     /** True if [cancelAll] was called at least once. */
     var cancelAllCalled: Boolean = false
         private set
@@ -61,9 +67,11 @@ class FakeBackgroundTaskScheduler(
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String>,
+        deadlineMs: Long?
     ): ScheduleResult {
-        enqueuedTasks += EnqueuedTask(id, trigger, workerClassName, constraints, inputJson, policy)
+        enqueuedTasks += EnqueuedTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
         return defaultResult
     }
 
@@ -73,6 +81,14 @@ class FakeBackgroundTaskScheduler(
 
     override fun cancelAll() {
         cancelAllCalled = true
+    }
+
+    override fun cancelByTag(tag: String) {
+        cancelledTags += tag
+    }
+
+    override fun cancelByWorkerClass(workerClassName: String) {
+        cancelledWorkerClasses += workerClassName
     }
 
     override fun flushPendingProgress() {
@@ -99,6 +115,8 @@ class FakeBackgroundTaskScheduler(
     fun reset() {
         enqueuedTasks.clear()
         cancelledIds.clear()
+        cancelledTags.clear()
+        cancelledWorkerClasses.clear()
         cancelAllCalled = false
         enqueuedChains.clear()
         flushCount = 0
@@ -135,7 +153,9 @@ class FakeBackgroundTaskScheduler(
         val workerClassName: String,
         val constraints: Constraints,
         val inputJson: String?,
-        val policy: ExistingPolicy
+        val policy: ExistingPolicy,
+        val tags: Set<String> = emptySet(),
+        val deadlineMs: Long? = null
     )
 
     data class EnqueuedChain(

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/ChainExecutor.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/ChainExecutor.kt
@@ -4,6 +4,7 @@ package dev.brewkits.kmpworkmanager.background.data
 
 import dev.brewkits.kmpworkmanager.KmpWorkManagerRuntime
 import dev.brewkits.kmpworkmanager.background.domain.BGTaskType
+import dev.brewkits.kmpworkmanager.background.domain.ChainInputMerger
 import dev.brewkits.kmpworkmanager.background.domain.ExecutionRecord
 import dev.brewkits.kmpworkmanager.background.domain.ExecutionStatus
 import dev.brewkits.kmpworkmanager.background.domain.TaskCompletionEvent
@@ -221,6 +222,18 @@ class ChainExecutor(
         // 10 minutes was too long — if the process is killed every 5 min (notification handler),
         // chains piled up in the queue but never executed (stuck behind stale locks).
         const val STALE_LOCK_TIMEOUT_MS = 3 * 60 * 1_000L // 3 minutes
+
+        /**
+         * Merges [previousOutput] into [baseInputJson] for the InputMerger pipeline (P1-D).
+         *
+         * Delegates to [ChainInputMerger], which is shared with Android so both platforms
+         * observe identical overwriting-merge semantics. Kept as a thin alias here because
+         * the iOS chain-execution tests reference it by this name.
+         */
+        internal fun buildMergedInput(
+            baseInputJson: String?,
+            previousOutput: kotlinx.serialization.json.JsonObject
+        ): String = ChainInputMerger.merge(baseInputJson, previousOutput)
     }
 
     /**
@@ -922,6 +935,12 @@ class ChainExecutor(
             try {
                 val chainOutcome = withTimeoutOrNull(chainTimeout) {
                     var allStepsSucceeded = true
+                    // InputMerger (P1-D): track the output of the most recently completed step.
+                    // Only non-null when the previous step returned WorkerResult.Success.data.
+                    // Passed into executeStep so tasks with mergeOutputFromPreviousStep=true
+                    // receive the merged JSON before their doWork() is called.
+                    var previousStepOutput: kotlinx.serialization.json.JsonObject? = null
+
                     for ((index, step) in steps.withIndex()) {
                         // Skip already completed steps
                         if (progress.isStepCompleted(index)) {
@@ -931,7 +950,7 @@ class ChainExecutor(
 
                         Logger.i(LogTags.CHAIN, "Executing step ${index + 1}/${steps.size} for chain $chainId (${step.size} tasks)")
 
-                        val stepOutcome = executeStep(step, index, progress, chainId)
+                        val stepOutcome = executeStep(step, index, progress, chainId, previousStepOutput)
                         progress = stepOutcome.updatedProgress
                         val stepError = stepOutcome.errorMessage
                         if (!stepOutcome.success) {
@@ -1037,14 +1056,21 @@ class ChainExecutor(
                             break
                         }
 
-                        // Step succeeded - update progress
+                        // Step succeeded - update progress and capture output for InputMerger
                         withContext(NonCancellable) {
                             progress = progress.withCompletedStep(index)
                             fileStorage.saveChainProgress(progress)
                         }
+                        // Forward this step's output to the next step (InputMerger P1-D).
+                        // Only set when the step produced non-null data; if null, the next
+                        // step's mergeOutputFromPreviousStep tasks will receive an empty merge.
+                        previousStepOutput = stepOutcome.outputData
+                        val forwardedNote =
+                            if (previousStepOutput != null) ", output forwarded to next step" else ""
                         Logger.d(
                             LogTags.CHAIN,
-                            "Step ${index + 1}/${steps.size} completed for chain $chainId (${progress.getCompletionPercentage()}% complete)"
+                            "Step ${index + 1}/${steps.size} completed for chain $chainId " +
+                                "(${progress.getCompletionPercentage()}% complete$forwardedNote)"
                         )
                     }
                     allStepsSucceeded
@@ -1224,6 +1250,12 @@ class ChainExecutor(
      * Tasks that already completed in a previous attempt (recorded in progress)
      * are skipped, making retry of partially-failed parallel steps idempotent.
      *
+     * **InputMerger (P1-D):**
+     * When [previousStepOutput] is non-null and a task sets [TaskRequest.mergeOutputFromPreviousStep]
+     * to `true`, the output JSON from the previous step is merged into the task's `inputJson`
+     * before `doWork()` is called. Fields from the previous step **overwrite** same-key fields
+     * in the original `inputJson` (consistent with WorkManager's `OverwritingInputMerger`).
+     *
      * **Per-task progress persistence (intentional design):**
      * Each task saves progress to the buffer immediately after it succeeds — not after
      * the entire step completes. This preserves partial progress on mid-step crashes:
@@ -1239,19 +1271,27 @@ class ChainExecutor(
      *
      * @return [StepOutcome] capturing the aggregate result of the step, including any
      *   Retry hints emitted by the FIRST failed task (used by the chain executor to set
-     *   `BGProcessingTaskRequest.earliestBeginDate` and enforce per-step `attemptCap`).
+     *   `BGProcessingTaskRequest.earliestBeginDate` and enforce per-step `attemptCap`),
+     *   and the merged output data from the last successfully completing task (for InputMerger).
      */
     private suspend fun executeStep(
         tasks: List<TaskRequest>,
         stepIndex: Int,
         progress: ChainProgress,
-        chainId: String
+        chainId: String,
+        previousStepOutput: kotlinx.serialization.json.JsonObject? = null
     ): StepOutcome {
         if (tasks.isEmpty()) return StepOutcome(success = true, updatedProgress = progress)
 
         var currentProgress = progress
         // Shared across all async blocks launched below — do not extract into a separate function.
         val progressMutex = Mutex()
+        // Accumulates the output data from successful tasks for InputMerger forwarding.
+        // Last non-null outputData wins (tasks within a parallel step run concurrently;
+        // the final value is non-deterministic for parallel steps with multiple data-producing
+        // tasks — callers should use InputMerger on sequential single-task steps when ordering matters).
+        var stepOutputData: kotlinx.serialization.json.JsonObject? = null
+        val outputMutex = Mutex()
 
         // Each async block returns a TaskOutcome carrying success + (optional) Retry hints.
         val results: List<TaskOutcome> = coroutineScope {
@@ -1265,7 +1305,13 @@ class ChainExecutor(
                         return@async TaskOutcome(success = true)
                     }
 
-                    val result = executeTask(task, chainId, stepIndex, progress.retryCount)
+                    // InputMerger: inject previous step output into this task's input if requested.
+                    val effectiveTask = if (task.mergeOutputFromPreviousStep && previousStepOutput != null) {
+                        val merged = buildMergedInput(task.inputJson, previousStepOutput)
+                        task.copy(inputJson = merged)
+                    } else task
+
+                    val result = executeTask(effectiveTask, chainId, stepIndex, progress.retryCount)
                     val success = result is WorkerResult.Success
                     if (success) {
                         withContext(NonCancellable) {
@@ -1273,6 +1319,11 @@ class ChainExecutor(
                                 currentProgress = currentProgress.withCompletedTaskInStep(stepIndex, taskIndex)
                                 fileStorage.saveChainProgress(currentProgress)
                             }
+                        }
+                        // Capture output data for InputMerger forwarding to next step.
+                        val successData = (result as WorkerResult.Success).data
+                        if (successData != null) {
+                            outputMutex.withLock { stepOutputData = successData }
                         }
                     }
                     when (result) {
@@ -1310,6 +1361,7 @@ class ChainExecutor(
         return StepOutcome(
             success = allSucceeded,
             updatedProgress = currentProgress,
+            outputData = stepOutputData,
             errorMessage = firstFailure?.errorMessage,
             retryDelayMs = firstFailure?.retryDelayMs,
             attemptCap = firstFailure?.attemptCap,
@@ -1339,10 +1391,15 @@ class ChainExecutor(
      * task (deterministic by iteration order). When a step has multiple failing tasks
      * with conflicting hints, the first one wins — callers should treat the values as
      * "guidance, not contract" and ensure their workers agree if they care about ordering.
+     *
+     * [outputData] holds the merged output from all successful tasks in this step,
+     * forwarded to the next step by the InputMerger when [TaskRequest.mergeOutputFromPreviousStep]
+     * is set. Last writer wins for parallel steps with multiple data-producing tasks.
      */
     private data class StepOutcome(
         val success: Boolean,
         val updatedProgress: ChainProgress,
+        val outputData: kotlinx.serialization.json.JsonObject? = null,  // InputMerger: forwarded to next step
         val errorMessage: String? = null,
         val retryDelayMs: Long? = null,
         val attemptCap: Int? = null,
@@ -1379,6 +1436,44 @@ class ChainExecutor(
                 message = "Requires unmetered (Wi-Fi) network but cellular is active",
                 shouldRetry = true
             )
+        }
+
+        // Deadline guard (P1-C): skip tasks whose business window has closed.
+        //
+        // Returns Success — deliberately, and this is the subtle part. A deadline miss is
+        // not a worker failure: the task chose not to run. Returning Failure here would
+        // abort the whole chain at this step, so a chain like
+        // `download → (deadline-bound) analytics-ping → upload` would lose its upload
+        // because an optional middle step went stale. Success skips just this task and lets
+        // the chain continue, and (being terminal) it is never retried.
+        //
+        // This mirrors Android exactly, where BaseKmpWorker returns `Result.success()` for
+        // the same condition while recording ExecutionStatus.SKIPPED. The emitted
+        // TaskCompletionEvent carries success=false on both platforms so observers can still
+        // see that the work did not actually happen.
+        val deadlineMs = task.deadlineMs
+        if (deadlineMs != null) {
+            val nowMs = (NSDate().timeIntervalSince1970 * 1000).toLong()
+            if (nowMs > deadlineMs) {
+                Logger.w(
+                    LogTags.CHAIN,
+                    "⏰ Task ${task.workerClassName} DEADLINE_EXCEEDED — deadline was " +
+                        "${NSDate.dateWithTimeIntervalSince1970(deadlineMs / 1000.0)}, " +
+                        "now=${NSDate.dateWithTimeIntervalSince1970(nowMs / 1000.0)}. " +
+                        "Skipping task to prevent stale-data side-effects; chain continues."
+                )
+                TaskEventBus.emit(
+                    TaskCompletionEvent(
+                        taskName = task.workerClassName,
+                        success = false,
+                        message = "Deadline exceeded — task skipped"
+                    )
+                )
+                return WorkerResult.Success(
+                    message = "Deadline exceeded — task skipped (deadlineMs=$deadlineMs, nowMs=$nowMs)",
+                    data = null  // nothing to forward to the next step's InputMerger
+                )
+            }
         }
 
         val worker = workerFactory.createWorker(task.workerClassName)

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/DynamicTaskDispatcher.kt
@@ -6,6 +6,8 @@
 package dev.brewkits.kmpworkmanager.background.data
 
 import dev.brewkits.kmpworkmanager.background.domain.BackgroundTaskScheduler
+import dev.brewkits.kmpworkmanager.background.domain.TaskCompletionEvent
+import dev.brewkits.kmpworkmanager.background.domain.TaskEventManager
 import dev.brewkits.kmpworkmanager.background.domain.WorkerResult
 import dev.brewkits.kmpworkmanager.utils.Logger
 import dev.brewkits.kmpworkmanager.utils.LogTags
@@ -63,6 +65,22 @@ public class DynamicTaskDispatcher(
         // i.e. >= 0). Bounds a `Failure(shouldRetry = true)` retry loop that carries no
         // per-result attemptCap. Absent → fall back to [DEFAULT_ATTEMPT_CAP].
         internal const val META_MAX_RETRIES = "maxRetries"
+
+        /**
+         * Task metadata key holding [dev.brewkits.kmpworkmanager.background.domain.TaskRequest.deadlineMs]
+         * (Unix epoch ms) for a standalone task. Written by `NativeTaskScheduler.enqueue`,
+         * read here at dispatch time. Absent means "no deadline".
+         */
+        internal const val META_DEADLINE_MS = "kmpDeadlineMs"
+
+        /**
+         * Task metadata key holding a standalone task's user tags, comma-separated.
+         * Read by `NativeTaskScheduler.cancelByTag` to resolve which tasks a tag covers.
+         *
+         * Comma is a safe separator here because [validateTaskTag] rejects it at the API
+         * boundary, so a tag can never contain one.
+         */
+        internal const val META_TAGS = "kmpTags"
 
         // Hard ceiling when the worker did not specify [WorkerResult.Retry.attemptCap] and
         // the caller set no Constraints.maxRetries. Mirrors WorkManager's default backoff
@@ -139,6 +157,32 @@ public class DynamicTaskDispatcher(
             val meta = IosBackgroundTaskHandler.resolveTaskMetadata(taskId, fileStorage)
             if (meta == null) {
                 Logger.e(LogTags.SCHEDULER, "No metadata found for dynamic task '$taskId' - skipping")
+                continue
+            }
+
+            // Deadline guard (P1-C) for standalone tasks. BGTaskScheduler is opportunistic:
+            // `earliestBeginDate` is a floor, never a ceiling, so a task can surface hours
+            // after the window its data was useful in. Checking at dispatch time — after the
+            // OS finally woke us — is the only place the real elapsed delay is known.
+            //
+            // Mirrors Android's BaseKmpWorker deadline guard, and like it, drops the task
+            // instead of retrying: a missed deadline cannot be un-missed by running later.
+            val deadlineMs = meta.rawMeta?.get(META_DEADLINE_MS)?.toLongOrNull()
+            if (deadlineMs != null && currentTimeMs() > deadlineMs) {
+                Logger.w(
+                    LogTags.SCHEDULER,
+                    "⏰ Dynamic task '$taskId' SKIPPED — deadline exceeded " +
+                        "(deadline=${deadlineMs}ms, now=${currentTimeMs()}ms). " +
+                        "Dropping instead of executing to avoid stale-data side-effects."
+                )
+                TaskEventManager.emit(
+                    TaskCompletionEvent(
+                        taskName = meta.workerClassName,
+                        success = false,
+                        message = "Deadline exceeded — task skipped"
+                    )
+                )
+                fileStorage.deleteTaskMetadata(taskId, periodic = false)
                 continue
             }
 

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/IosFileStorage.kt
@@ -936,6 +936,31 @@ public class IosFileStorage(
     suspend fun getActiveChainIds(): List<String> = queue.getAllItems()
 
     /**
+     * Scans all chain IDs currently in the execution queue and returns those whose
+     * definition contains at least one task matching [workerClassName] OR whose
+     * [TaskRequest.tags] contains [tag].
+     *
+     * Either [workerClassName] or [tag] may be null — omitting both returns an empty list.
+     *
+     * **Performance:** O(N × S) where N = queue depth and S = average steps per chain.
+     * This is a fire-and-forget maintenance path, not on the hot execution path.
+     */
+    suspend fun findChainIdsByWorkerOrTag(
+        workerClassName: String? = null,
+        tag: String? = null
+    ): List<String> {
+        if (workerClassName == null && tag == null) return emptyList()
+        val allChainIds = queue.getAllItems()
+        return allChainIds.filter { chainId ->
+            val steps = loadChainDefinition(chainId) ?: return@filter false
+            steps.flatten().any { task ->
+                (workerClassName != null && task.workerClassName == workerClassName) ||
+                (tag != null && tag in task.tags)
+            }
+        }
+    }
+
+    /**
      * Get hours since last maintenance run
      *
      * @return Hours since last maintenance, or Int.MAX_VALUE if never run
@@ -1389,6 +1414,47 @@ public class IosFileStorage(
     }
 
     /**
+     * Finds standalone (non-chain) task IDs whose stored metadata matches [workerClassName]
+     * or carries [tag], scanning both the one-time and periodic metadata directories.
+     *
+     * The chain-side counterpart is [findChainIdsByWorkerOrTag]; both are needed because a
+     * task can be scheduled either way and `cancelByTag` must reach both. Returns pairs of
+     * `(taskId, isPeriodic)` so the caller can delete the right metadata file — the two
+     * directories can legitimately hold the same id.
+     *
+     * Either parameter may be null; passing both as null returns an empty list.
+     */
+    fun findTaskIdsByWorkerOrTag(
+        workerClassName: String? = null,
+        tag: String? = null
+    ): List<Pair<String, Boolean>> {
+        if (workerClassName == null && tag == null) return emptyList()
+        val matches = mutableListOf<Pair<String, Boolean>>()
+
+        listOf(tasksDirURL to false, periodicDirURL to true).forEach { (dir, isPeriodic) ->
+            val path = dir.path ?: return@forEach
+            val files = fileManager.contentsOfDirectoryAtPath(path, null) as? List<*> ?: return@forEach
+
+            files.forEach fileLoop@{ fileName ->
+                val name = fileName as? String ?: return@fileLoop
+                if (!name.endsWith(".json")) return@fileLoop
+                val taskId = name.removeSuffix(".json").decodeFromPathComponent()
+                val meta = loadTaskMetadata(taskId, periodic = isPeriodic) ?: return@fileLoop
+
+                val workerMatches = workerClassName != null &&
+                    meta["workerClassName"] == workerClassName
+                val tagMatches = tag != null &&
+                    meta[DynamicTaskDispatcher.META_TAGS]
+                        ?.split(',')
+                        ?.any { it == tag } == true
+
+                if (workerMatches || tagMatches) matches += taskId to isPeriodic
+            }
+        }
+        return matches
+    }
+
+    /**
      * Cleanup stale metadata older than specified days
      */
     fun cleanupStaleMetadata(olderThanDays: Int = 7) {
@@ -1707,6 +1773,24 @@ internal fun String.encodeAsPathComponent(): String {
     if (this == "..") return "%2E%2E"
     if ('%' !in this && '/' !in this) return this
     return replace("%", "%25").replace("/", "%2F")
+}
+
+/**
+ * Exact inverse of [encodeAsPathComponent] — recovers a task/chain id from its on-disk
+ * filename. Needed when enumerating a metadata directory, where the filename is the only
+ * record of the id (see [IosFileStorage.findTaskIdsByWorkerOrTag]).
+ *
+ * **Replacement order is the reverse of the encoder's and must stay that way.** The encoder
+ * escapes `%` *before* `/`, so the decoder must unescape `/` *before* `%`. Decoding in the
+ * other order would corrupt any id containing the literal text `"%2F"`: `"a%2Fb"` encodes to
+ * `"a%252Fb"`, and unescaping `%25`→`%` first would yield `"a%2Fb"` which a subsequent
+ * `%2F`→`/` pass would then wrongly turn into `"a/b"` — a different id.
+ */
+internal fun String.decodeFromPathComponent(): String {
+    if (this == "%2E") return "."
+    if (this == "%2E%2E") return ".."
+    if ('%' !in this) return this
+    return replace("%2F", "/").replace("%25", "%")
 }
 
 /** Converts a UTF-8 string to NSData using byte array encoding (not char count). */

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -226,8 +226,14 @@ public class NativeTaskScheduler(
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String>,
+        deadlineMs: Long?
     ): ScheduleResult {
+        // Fail fast on unusable tags rather than at cancelByTag() time, where a bad tag
+        // would look like "nothing matched" instead of "the tag was never storable".
+        tags.forEach { validateTaskTag(it) }
+
         // Wait for migration to complete before accessing storage.
         // Guard with a timeout: if migration hangs (e.g. corrupted store), we reject rather than deadlock.
         if (!isTestMode || forceWaitMigration) {
@@ -249,10 +255,10 @@ public class NativeTaskScheduler(
 
         @Suppress("DEPRECATION")  // Keep backward compatibility for deprecated triggers 
         val result = when (trigger) {
-            is TaskTrigger.Periodic -> schedulePeriodicTask(id, trigger, workerClassName, constraints, inputJson, policy)
-            is TaskTrigger.OneTime -> scheduleOneTimeTask(id, trigger, workerClassName, constraints, inputJson, policy)
+            is TaskTrigger.Periodic -> schedulePeriodicTask(id, trigger, workerClassName, constraints, inputJson, policy, tags)
+            is TaskTrigger.OneTime -> scheduleOneTimeTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
             is TaskTrigger.Exact -> scheduleExactAlarm(id, trigger, workerClassName, constraints, inputJson)
-            is TaskTrigger.Windowed -> scheduleWindowedTask(id, trigger, workerClassName, constraints, inputJson, policy)
+            is TaskTrigger.Windowed -> scheduleWindowedTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
             is TaskTrigger.ContentUri -> rejectUnsupportedTrigger("ContentUri")
         }
 
@@ -328,7 +334,8 @@ public class NativeTaskScheduler(
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String> = emptySet()
     ): ScheduleResult {
         val intervalMs = trigger.intervalMs
 
@@ -393,16 +400,19 @@ public class NativeTaskScheduler(
         }
 
         // Save metadata for re-scheduling after execution; preserve anchoredStartMs
-        val periodicMetadata = mapOf(
-            "isPeriodic" to "true",
-            "intervalMs" to "$intervalMs",
-            "anchoredStartMs" to "$anchoredStartMs",
-            "workerClassName" to workerClassName,
-            "inputJson" to (inputJson ?: ""),
-            "requiresNetwork" to "${constraints.requiresNetwork}",
-            "requiresCharging" to "${constraints.requiresCharging}",
-            "isHeavyTask" to "${constraints.isHeavyTask}"
-        )
+        val periodicMetadata = buildMap {
+            put("isPeriodic", "true")
+            put("intervalMs", "$intervalMs")
+            put("anchoredStartMs", "$anchoredStartMs")
+            put("workerClassName", workerClassName)
+            put("inputJson", inputJson ?: "")
+            put("requiresNetwork", "${constraints.requiresNetwork}")
+            put("requiresCharging", "${constraints.requiresCharging}")
+            put("isHeavyTask", "${constraints.isHeavyTask}")
+            if (tags.isNotEmpty()) put(DynamicTaskDispatcher.META_TAGS, tags.joinToString(","))
+            // No deadline for periodic work — see the matching note in Android's
+            // schedulePeriodicWork: a deadline on a recurring task is a delayed cancel.
+        }
         fileStorage.saveTaskMetadata(id, periodicMetadata, periodic = true)
 
         val request = createBackgroundTaskRequest(id, constraints)
@@ -420,7 +430,9 @@ public class NativeTaskScheduler(
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String> = emptySet(),
+        deadlineMs: Long? = null
     ): ScheduleResult {
         Logger.i(LogTags.SCHEDULER, "Scheduling one-time task - ID: '$id', Delay: ${trigger.initialDelayMs}ms")
 
@@ -440,6 +452,10 @@ public class NativeTaskScheduler(
             if (constraints.maxRetries >= 0) {
                 put(DynamicTaskDispatcher.META_MAX_RETRIES, "${constraints.maxRetries}")
             }
+            // Only written when set, so existing metadata files stay byte-identical for
+            // callers that never use tags/deadlines (keeps upgrades a no-op on disk).
+            if (tags.isNotEmpty()) put(DynamicTaskDispatcher.META_TAGS, tags.joinToString(","))
+            if (deadlineMs != null) put(DynamicTaskDispatcher.META_DEADLINE_MS, "$deadlineMs")
         }
         fileStorage.saveTaskMetadata(id, taskMetadata, periodic = false)
 
@@ -476,7 +492,9 @@ public class NativeTaskScheduler(
         workerClassName: String,
         constraints: Constraints,
         inputJson: String?,
-        policy: ExistingPolicy
+        policy: ExistingPolicy,
+        tags: Set<String> = emptySet(),
+        deadlineMs: Long? = null
     ): ScheduleResult {
         val nowMs = (NSDate().timeIntervalSince1970 * 1000).toLong()
         val earliestDate = NSDate.dateWithTimeIntervalSince1970(trigger.earliest / 1000.0)
@@ -522,12 +540,18 @@ public class NativeTaskScheduler(
             return ScheduleResult.ACCEPTED
         }
 
-        val taskMetadata = mapOf(
-            "workerClassName" to workerClassName,
-            "inputJson" to (inputJson ?: ""),
-            "windowEarliest" to trigger.earliest.toString(),
-            "windowLatest" to trigger.latest.toString()
-        )
+        val taskMetadata = buildMap {
+            put("workerClassName", workerClassName)
+            put("inputJson", inputJson ?: "")
+            put("windowEarliest", trigger.earliest.toString())
+            put("windowLatest", trigger.latest.toString())
+            if (tags.isNotEmpty()) put(DynamicTaskDispatcher.META_TAGS, tags.joinToString(","))
+            // A Windowed trigger's `latest` IS a deadline and iOS cannot enforce it natively,
+            // so default to it when the caller gave no explicit deadline. This is what finally
+            // makes `latest` mean something on iOS instead of being a logged warning.
+            val effectiveDeadline = deadlineMs ?: trigger.latest
+            put(DynamicTaskDispatcher.META_DEADLINE_MS, "$effectiveDeadline")
+        }
         fileStorage.saveTaskMetadata(id, taskMetadata, periodic = false)
 
         val request = createBackgroundTaskRequest(id, constraints)
@@ -580,6 +604,18 @@ public class NativeTaskScheduler(
                     // Note: cancel() also deletes metadata; callers reading metadata for reschedule
                     // (e.g. schedulePeriodicTask) must read metadata BEFORE calling this function.
                     cancel(id)
+                    return true
+                }
+                ExistingPolicy.UPDATE -> {
+                    // UPDATE: update constraints/input without resetting the interval timer.
+                    // Callers (schedulePeriodicTask) have already read anchoredStartMs from metadata
+                    // BEFORE invoking this function. We cancel the pending BGTask request so the
+                    // new one (with updated earliestBeginDate) can be submitted, but we do NOT
+                    // delete the metadata — schedulePeriodicTask will overwrite it with updated
+                    // constraints while preserving the existing anchoredStartMs.
+                    Logger.i(LogTags.SCHEDULER, "UPDATE policy for task '$id': cancelling pending BGTask, preserving timer anchor")
+                    BGTaskScheduler.sharedScheduler.cancelTaskRequestWithIdentifier(id)
+                    // Do NOT call cancel(id) here — that deletes metadata, which would lose anchoredStartMs.
                     return true
                 }
             }
@@ -1186,29 +1222,40 @@ public class NativeTaskScheduler(
         val chainId = id ?: NSUUID.UUID().UUIDString()
         Logger.i(LogTags.CHAIN, "Enqueuing chain - ID: $chainId, Steps: ${steps.size}, Policy: $policy")
 
-        if (policy == ExistingPolicy.REPLACE) {
+        // UPDATE has no interval-preserving meaning for chains (there is no recurring
+        // anchor to preserve — a chain is a one-shot pipeline), so it degrades to REPLACE
+        // here. This matches Android, where enqueueChain maps UPDATE to
+        // ExistingWorkPolicy.REPLACE for the same reason. UPDATE only carries its distinct
+        // "keep the timer anchor" semantics on periodic tasks (see handleExistingPolicy).
+        //
+        // Kept as an exhaustive `when` rather than a boolean: when ExistingPolicy.APPEND
+        // is added, the compiler must force a decision here instead of silently routing
+        // APPEND down the KEEP branch. Android's enqueueChain relies on the same guard.
+        val chainPolicyIsReplace = when (policy) {
+            ExistingPolicy.REPLACE, ExistingPolicy.UPDATE -> true
+            ExistingPolicy.KEEP -> false
+        }
+
+        if (chainPolicyIsReplace) {
             // Cancel any running execution of this chain across ALL ChainExecutor
             // instances (e.g. a prior BGTask still running when the new request arrives).
             ChainJobRegistry.cancel(chainId)
         }
 
         if (fileStorage.chainExists(chainId)) {
-            when (policy) {
-                ExistingPolicy.KEEP -> {
-                    Logger.i(LogTags.CHAIN, "Chain $chainId already exists, KEEP policy - skipping")
-                    return
-                }
-                ExistingPolicy.REPLACE -> {
-                    Logger.i(LogTags.CHAIN, "Chain $chainId exists, REPLACE policy - using atomic replace...")
-                    try {
-                        fileStorage.replaceChainAtomic(chainId, steps)
-                        Logger.i(LogTags.CHAIN, "✅ Chain $chainId replaced atomically")
-                        return // Early return - atomic operation already enqueued
-                    } catch (e: Exception) {
-                        Logger.e(LogTags.CHAIN, "Failed to replace chain $chainId atomically", e)
-                        throw e
-                    }
-                }
+            if (!chainPolicyIsReplace) {
+                // KEEP: leave the existing chain untouched.
+                Logger.i(LogTags.CHAIN, "Chain $chainId already exists, KEEP policy - skipping")
+                return
+            }
+            Logger.i(LogTags.CHAIN, "Chain $chainId exists, $policy policy - using atomic replace...")
+            try {
+                fileStorage.replaceChainAtomic(chainId, steps)
+                Logger.i(LogTags.CHAIN, "✅ Chain $chainId replaced atomically")
+                return // Early return - atomic operation already enqueued
+            } catch (e: Exception) {
+                Logger.e(LogTags.CHAIN, "Failed to replace chain $chainId atomically", e)
+                throw e
             }
         }
 
@@ -1284,6 +1331,90 @@ public class NativeTaskScheduler(
         fileStorage.deleteTaskMetadata(id, periodic = true)
 
         Logger.d(LogTags.SCHEDULER, "Cancelled task '$id' and cleaned up metadata")
+    }
+
+    /**
+     * Cancels all pending or running tasks that carry the given user-defined tag.
+     *
+     * Scans the chain queue and cancels all chains containing a [TaskRequest] whose
+     * [TaskRequest.tags] includes [tag]. Active (running) chains are cancelled via
+     * [ChainJobRegistry]. Runs on the background scope to avoid blocking the caller.
+     */
+    override fun cancelByTag(tag: String) {
+        Logger.i(LogTags.SCHEDULER, "Cancelling tasks and chains by tag '$tag'")
+        backgroundScope.launch {
+            cancelMatching(tag = tag, workerClassName = null, reason = "tag='$tag'")
+        }
+    }
+
+    /**
+     * Shared body of [cancelByTag] and [cancelByWorkerClass].
+     *
+     * Covers **both** storage shapes a task can live in — chains (queue + definition files)
+     * and standalone tasks (metadata files) — because callers think in terms of "cancel my
+     * work", not in terms of which API scheduled it. Missing either half would make
+     * cancellation silently partial, which is worse than not offering it.
+     */
+    private suspend fun cancelMatching(tag: String?, workerClassName: String?, reason: String) {
+        val chainIds = fileStorage.findChainIdsByWorkerOrTag(workerClassName = workerClassName, tag = tag)
+        val taskIds = fileStorage.findTaskIdsByWorkerOrTag(workerClassName = workerClassName, tag = tag)
+        Logger.d(
+            LogTags.SCHEDULER,
+            "Found ${chainIds.size} chain(s) and ${taskIds.size} standalone task(s) matching $reason"
+        )
+
+        for (chainId in chainIds) {
+            cancelChainById(chainId, reason)
+        }
+        for ((taskId, isPeriodic) in taskIds) {
+            // Withdraw the pending BGTask request, then drop the metadata the dispatcher
+            // would otherwise resolve on its next wake-up.
+            BGTaskScheduler.sharedScheduler.cancelTaskRequestWithIdentifier(taskId)
+            fileStorage.deleteTaskMetadata(taskId, periodic = isPeriodic)
+            Logger.d(
+                LogTags.SCHEDULER,
+                "Cancelled standalone ${if (isPeriodic) "periodic" else "one-time"} task $taskId ($reason)"
+            )
+        }
+    }
+
+    /**
+     * Cancels one queued or running chain and leaves the queue in a state [ChainExecutor]
+     * can drain cleanly.
+     *
+     * The deleted-marker write is what makes this safe. Chain IDs live in an append-only
+     * queue that has no random-access removal, so a cancelled ID necessarily stays queued
+     * until the executor reaches it. Without the marker, the executor would dequeue the ID,
+     * find no definition, and log a `Logger.e("No chain definition found")` — an error-level
+     * report of a cancellation the caller deliberately requested. With the marker, it takes
+     * the existing "chain was cancelled" branch: INFO log, clean skip, marker cleared.
+     */
+    private suspend fun cancelChainById(chainId: String, reason: String) {
+        // Stop the running coroutine first so it cannot re-save progress underneath us.
+        ChainJobRegistry.cancel(chainId)
+        // Order matters: publish the tombstone before removing the definition, so an executor
+        // racing us sees "cancelled" rather than "definition missing".
+        fileStorage.markChainAsDeleted(chainId)
+        fileStorage.deleteChainDefinition(chainId)
+        fileStorage.deleteChainProgress(chainId)
+        Logger.d(LogTags.SCHEDULER, "Cancelled chain $chainId ($reason)")
+    }
+
+    /**
+     * Cancels all pending or running tasks whose [TaskRequest.workerClassName] matches
+     * [workerClassName].
+     *
+     * Equivalent to scanning chains for the worker class name.
+     */
+    override fun cancelByWorkerClass(workerClassName: String) {
+        Logger.i(LogTags.SCHEDULER, "Cancelling chains by worker class '$workerClassName'")
+        backgroundScope.launch {
+            cancelMatching(
+                tag = null,
+                workerClassName = workerClassName,
+                reason = "worker='$workerClassName'"
+            )
+        }
     }
 
     override fun cancelAll() {

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosBackgroundTaskHandlerTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosBackgroundTaskHandlerTest.kt
@@ -76,7 +76,9 @@ class IosBackgroundTaskHandlerTest {
             workerClassName: String,
             constraints: Constraints,
             inputJson: String?,
-            policy: ExistingPolicy
+            policy: ExistingPolicy,
+            tags: Set<String>,
+            deadlineMs: Long?
         ): ScheduleResult {
             lastEnqueue = EnqueueCall(id, trigger, workerClassName, constraints, inputJson, policy)
             return ScheduleResult.ACCEPTED
@@ -84,6 +86,8 @@ class IosBackgroundTaskHandlerTest {
 
         override fun cancel(id: String) = Unit
         override fun cancelAll() = Unit
+        override fun cancelByTag(tag: String) = Unit
+        override fun cancelByWorkerClass(workerClassName: String) = Unit
         override fun beginWith(task: TaskRequest): TaskChain = throw UnsupportedOperationException()
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = throw UnsupportedOperationException()
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) = Unit

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosDynamicTaskDispatcherTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/IosDynamicTaskDispatcherTest.kt
@@ -38,9 +38,11 @@ class IosDynamicTaskDispatcherTest {
     }
 
     private fun makeSchedulerStub(): BackgroundTaskScheduler = object : BackgroundTaskScheduler {
-        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy) = ScheduleResult.ACCEPTED
+        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy, tags: Set<String>, deadlineMs: Long?) = ScheduleResult.ACCEPTED
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = throw UnsupportedOperationException()
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = throw UnsupportedOperationException()
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {}

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V250DispatcherShutdownTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V250DispatcherShutdownTest.kt
@@ -53,9 +53,11 @@ class V250DispatcherShutdownTest {
         )
 
     private fun makeSchedulerStub(): BackgroundTaskScheduler = object : BackgroundTaskScheduler {
-        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy) = ScheduleResult.ACCEPTED
+        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy, tags: Set<String>, deadlineMs: Long?) = ScheduleResult.ACCEPTED
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = throw UnsupportedOperationException()
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = throw UnsupportedOperationException()
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {}

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V250DynamicRetryTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V250DynamicRetryTest.kt
@@ -42,9 +42,11 @@ class V250DynamicRetryTest {
     )
 
     private fun makeSchedulerStub(): BackgroundTaskScheduler = object : BackgroundTaskScheduler {
-        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy) = ScheduleResult.ACCEPTED
+        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy, tags: Set<String>, deadlineMs: Long?) = ScheduleResult.ACCEPTED
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = throw UnsupportedOperationException()
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = throw UnsupportedOperationException()
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {}

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V302RetryCapIosTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/V302RetryCapIosTest.kt
@@ -48,9 +48,11 @@ class V302RetryCapIosTest {
     )
 
     private fun schedulerStub(): BackgroundTaskScheduler = object : BackgroundTaskScheduler {
-        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy) = ScheduleResult.ACCEPTED
+        override suspend fun enqueue(id: String, trigger: TaskTrigger, workerClassName: String, constraints: Constraints, inputJson: String?, policy: ExistingPolicy, tags: Set<String>, deadlineMs: Long?) = ScheduleResult.ACCEPTED
         override fun cancel(id: String) {}
         override fun cancelAll() {}
+        override fun cancelByTag(tag: String) {}
+        override fun cancelByWorkerClass(workerClassName: String) {}
         override fun beginWith(task: TaskRequest): TaskChain = throw UnsupportedOperationException()
         override fun beginWith(tasks: List<TaskRequest>): TaskChain = throw UnsupportedOperationException()
         override suspend fun enqueueChain(chain: TaskChain, id: String?, policy: ExistingPolicy) {}


### PR DESCRIPTION
Implements four Jetpack WorkManager features that had no equivalent here, on **both** platforms rather than Android-only.

## Features

| Feature | API |
|---|---|
| Group cancellation | `TaskRequest.tags`, `enqueue(tags = …)`, `cancelByTag()`, `cancelByWorkerClass()` |
| Per-task deadline | `TaskRequest.deadlineMs`, `enqueue(deadlineMs = …)` |
| Chain InputMerger | `TaskRequest.mergeOutputFromPreviousStep` |
| Periodic update | `ExistingPolicy.UPDATE` |

Deadlines also give `TaskTrigger.Windowed.latest` real enforcement on iOS for the first time — BGTaskScheduler offers only `earliestBeginDate`, so `latest` was previously just a logged warning.

## Bugs found while reviewing the in-progress implementation

1. **Android InputMerger was entirely non-functional.** `KEY_MERGE_PREVIOUS_OUTPUT` was stamped but never read, and `BaseKmpWorker` returned `Result.success()` with no output `Data` — so a worker's `Success.data` never reached WorkManager and the default `OverwritingInputMerger` had nothing to merge. The feature worked on iOS and silently no-opped on Android. Now round-trips through a namespaced `KEY_STEP_OUTPUT`, with oversized payloads dropped rather than failing a step that actually succeeded.
2. **Merge logic was iOS-only** — extracted to `ChainInputMerger` in commonMain so the two engines cannot drift, pinned by commonTest.
3. **iOS `cancelByTag` left the queue inconsistent** — deleted a chain's definition without writing the deleted marker, so `ChainExecutor` would later dequeue the id, find nothing, and log an ERROR for a cancellation the caller had requested. Now writes the tombstone first so the existing cancelled-chain path handles it at INFO.
4. **Deadline semantics diverged** — Android skipped and continued; iOS returned `Failure`, aborting the whole chain. Unified on skip-and-continue: an optional stale step must not destroy the steps after it.
5. **Operator-precedence bug** in a log string dropped a closing paren.
6. **`tags`/`deadlineMs` were unreachable for standalone tasks** — `enqueue()` had no parameters for them, so `cancelByTag` could never match a non-chain task.

## Deliberate design decisions

- **InputMerger is opt-in** (`false` by default). Auto-forwarding would change behaviour for every existing chain and blend data between unrelated steps.
- **Tags are validated at construction** (non-blank, no commas, ≤100 chars). iOS persists a standalone task's tags as one comma-separated metadata string, so an embedded comma would split a tag and make `cancelByTag` silently fail to match — the worst failure mode for a cancellation API.
- **`cancelByTag` is not supported for `TaskTrigger.Exact` on Android** (AlarmManager is not tag-indexed). Logs a warning rather than failing silently.
- **Deadlines are ignored for periodic tasks** on both platforms — a deadline on a recurring task is a delayed cancel, not a deadline. Warned, not silently applied.
- **`ExistingPolicy.UPDATE` degrades to REPLACE** for one-time tasks and chains, which have no timer anchor to preserve. The `when` over `ExistingPolicy` in iOS `enqueueChain` is kept exhaustive so adding `APPEND` later forces a decision there instead of silently falling through to KEEP.

## Source compatibility

`cancelByTag`/`cancelByWorkerClass` ship with **no-op default implementations** so existing third-party schedulers and test doubles keep compiling. Classes that *override* `enqueue()` must add the two new (defaulted) parameters — 11 mocks in this repo needed that change, which is the evidence the default-impl decision was worth making for downstream users.

## Testing

30 new tests (`ChainInputMergerTest`, `TaskTagValidationTest`, `V350DeadlineAndInputMergerTest`), including a regression test proving a worker returning no data never re-emits the *previous* step's output — on Android the payload physically travels inside the next step's `inputData`, so echoing input to output would silently corrupt a pipeline.

Verified the suite actually catches the bug: reverting the Android InputMerger fix turns `successfulWorker_publishesOutputForTheNextStep` red.