### PR TITLE
fix(ios): serialize enqueue() to close TOCTOU race (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to KMP WorkManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **iOS: fixed a TOCTOU race in `NativeTaskScheduler.enqueue()`** where N concurrent
+  `enqueue()` calls for the same brand-new task id could all observe no existing metadata
+  before any of them wrote, race into the write path concurrently, and corrupt the on-disk
+  metadata. Fixed with a per-scheduler-instance `Mutex` serializing the check-then-act
+  scheduling decision, mirroring `IosFileStorage.enqueueMutex`'s existing pattern.
+  Fixes [#98](https://github.com/brewkits/kmpworkmanager/issues/98).
+
 ## [3.4.0] - 2026-09-02
 
 WorkManager parity pass (task tags, deadlines, InputMerger, `ExistingPolicy.UPDATE`),

--- a/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
+++ b/kmpworker/src/iosMain/kotlin/dev/brewkits/kmpworkmanager/background/data/NativeTaskScheduler.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -131,6 +133,25 @@ public class NativeTaskScheduler(
     }
 
     private val migration = StorageMigration(fileStorage = fileStorage)
+
+    /**
+     * Serializes enqueue()'s check-then-act scheduling decision (read metadata → apply
+     * ExistingPolicy → write metadata → submit) per scheduler instance — fixes #98: without
+     * this, N concurrent enqueue() calls for the same brand-new task id can all observe
+     * loadTaskMetadata() == null before any of them writes, race into the write path
+     * concurrently, and corrupt the on-disk metadata (observed as a null read after all
+     * writes should have succeeded). Mirrors IosFileStorage.enqueueMutex's established
+     * "wrap check-then-act in a single Mutex" idiom (see enqueueChain()) rather than
+     * ChainJobRegistry's job-cancellation registry, which solves a different problem shape.
+     *
+     * **Known limitation, not addressed here**: this is instance-scoped, not process-wide —
+     * two NativeTaskScheduler instances sharing the same IosFileStorage (e.g. a test
+     * constructing a second instance) are not mutually protected. Also does not synchronize
+     * against a concurrent external cancel(id) call, which is a non-suspend interface method
+     * and cannot take this lock. Both are pre-existing, narrower risk classes than #98's
+     * reported race; tracked separately rather than bundled into this fix.
+     */
+    private val schedulingMutex = Mutex()
 
     /**
      * Background scope for IO operations (migration, file access)
@@ -264,13 +285,15 @@ public class NativeTaskScheduler(
             return ScheduleResult.REJECTED_OS_POLICY
         }
 
-        @Suppress("DEPRECATION")  // Keep backward compatibility for deprecated triggers 
-        val result = when (trigger) {
-            is TaskTrigger.Periodic -> schedulePeriodicTask(id, trigger, workerClassName, constraints, inputJson, policy, tags)
-            is TaskTrigger.OneTime -> scheduleOneTimeTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
-            is TaskTrigger.Exact -> scheduleExactAlarm(id, trigger, workerClassName, constraints, inputJson)
-            is TaskTrigger.Windowed -> scheduleWindowedTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
-            is TaskTrigger.ContentUri -> rejectUnsupportedTrigger("ContentUri")
+        @Suppress("DEPRECATION")  // Keep backward compatibility for deprecated triggers
+        val result = schedulingMutex.withLock {
+            when (trigger) {
+                is TaskTrigger.Periodic -> schedulePeriodicTask(id, trigger, workerClassName, constraints, inputJson, policy, tags)
+                is TaskTrigger.OneTime -> scheduleOneTimeTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
+                is TaskTrigger.Exact -> scheduleExactAlarm(id, trigger, workerClassName, constraints, inputJson)
+                is TaskTrigger.Windowed -> scheduleWindowedTask(id, trigger, workerClassName, constraints, inputJson, policy, tags, deadlineMs)
+                is TaskTrigger.ContentUri -> rejectUnsupportedTrigger("ContentUri")
+            }
         }
 
         if (result == ScheduleResult.ACCEPTED) {

--- a/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/RaceConditionTest.kt
+++ b/kmpworker/src/iosTest/kotlin/dev/brewkits/kmpworkmanager/RaceConditionTest.kt
@@ -18,31 +18,41 @@ class RaceConditionTest {
         // open, it can outlive this test method and corrupt the next test's XML reporting.
         val scheduler = NativeTaskScheduler()
         try {
-            val taskId = "race-test-task"
-            val workerClassName = "TestWorker"
+            // 10 iterations x 5 concurrent racers on a FRESH id each time (never a
+            // pre-existing one) — regression guard for #98's schedulingMutex fix. A fresh id
+            // per iteration deliberately avoids exercising the KEEP-policy "existing metadata"
+            // branch, whose isTaskPending() staleness check always reports false in
+            // isTestMode (nothing is ever really submitted to BGTaskScheduler for a dynamic
+            // task id — see NativeTaskScheduler.kt's submitTaskRequest), making that branch
+            // untestable for this exact race scenario and irrelevant to the fix being guarded
+            // here (the brand-new-id TOCTOU, not KEEP's existing-metadata semantics).
+            repeat(10) { iteration ->
+                val taskId = "race-test-task-$iteration"
+                val workerClassName = "TestWorker"
 
-            // Send multiple concurrent requests with KEEP policy
-            // If a race condition occurs, multiple jobs might see metadata as null and attempt to save it simultaneously
-            val jobs = List(5) {
-                launch(Dispatchers.Default) {
-                    scheduler.enqueue(
-                        id = taskId,
-                        trigger = TaskTrigger.OneTime(0),
-                        workerClassName = workerClassName,
-                        constraints = Constraints(),
-                        inputJson = null,
-                        policy = ExistingPolicy.KEEP
-                    )
+                // Send multiple concurrent requests with KEEP policy.
+                // If a race condition occurs, multiple jobs might see metadata as null and attempt to save it simultaneously.
+                val jobs = List(5) {
+                    launch(Dispatchers.Default) {
+                        scheduler.enqueue(
+                            id = taskId,
+                            trigger = TaskTrigger.OneTime(0),
+                            workerClassName = workerClassName,
+                            constraints = Constraints(),
+                            inputJson = null,
+                            policy = ExistingPolicy.KEEP
+                        )
+                    }
                 }
+
+                jobs.joinAll()
+
+                // Verify data integrity is maintained — no corrupted/lost write from concurrent access.
+                val metadata = scheduler.fileStorage.loadTaskMetadata(taskId, periodic = false)
+                assertNotNull(metadata, "Metadata should exist after concurrent KEEP enqueues (iteration $iteration)")
+                assertEquals(workerClassName, metadata["workerClassName"], "Worker class name must be preserved correctly (iteration $iteration)")
+                assertEquals("", metadata["inputJson"], "inputJson must be written (empty string for null input) (iteration $iteration)")
             }
-
-            jobs.joinAll()
-
-            // Verify that exactly one enqueue won (KEEP policy) and data integrity is maintained.
-            val metadata = scheduler.fileStorage.loadTaskMetadata(taskId, periodic = false)
-            assertNotNull(metadata, "Metadata should exist after concurrent KEEP enqueues")
-            assertEquals(workerClassName, metadata["workerClassName"], "Worker class name must be preserved correctly")
-            assertEquals("", metadata["inputJson"], "inputJson must be written (empty string for null input)")
         } finally {
             scheduler.close()
         }


### PR DESCRIPTION
## Summary

Closes #98 — a TOCTOU race in `NativeTaskScheduler.enqueue()`: N concurrent calls for the
same brand-new task id could all observe no existing metadata before any of them wrote,
race into the write path concurrently, and corrupt the on-disk metadata.

Fix: a per-scheduler-instance `Mutex` around `enqueue()`'s trigger dispatch, covering the
whole check → apply-policy → write → submit span for every trigger type in one place.
Mirrors `IosFileStorage.enqueueMutex`'s existing "wrap check-then-act in a single Mutex"
idiom — `ChainJobRegistry` (the pattern the issue itself suggested) was investigated and
ruled out, since it solves a different problem shape (job-cancellation bookkeeping, not
concurrent-caller exclusion). See the new field's KDoc in `NativeTaskScheduler.kt` for the
full reasoning.

Also strengthens `RaceConditionTest` to repeat the race across 10 fresh task ids (50
concurrent enqueues total, up from 5) as a stronger regression guard, without touching the
KEEP-policy "existing metadata" branch (which has an unrelated, separately-tracked
testability limitation in `isTestMode` — see follow-up issue).

## Test plan

- [x] `./gradlew :kmpworker:iosSimulatorArm64Test --tests "*.RaceConditionTest"` — pass, run
      4 times in a row for confidence
- [x] `./gradlew :kmpworker:compileTestKotlinIosSimulatorArm64` — clean compile
- Note: this branch's own `./gradlew :kmpworker:check` full run hit the pre-existing,
  unrelated iOS native-test-runner flakiness documented for this repo (a different test
  class crash unrelated to this change) — the specific test this PR touches was verified in
  isolation instead, per that known limitation.